### PR TITLE
obs: golden flow dashboard, alerts, and prometheus

### DIFF
--- a/docker-compose.prometheus.yml
+++ b/docker-compose.prometheus.yml
@@ -1,0 +1,15 @@
+services:
+  prometheus:
+    image: prom/prometheus:v2.54.0
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --web.enable-lifecycle
+    volumes:
+      - ./prometheus:/etc/prometheus
+      - prometheus-data:/prometheus
+    ports:
+      - "9090:9090"
+
+volumes:
+  prometheus-data: {}

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -1,0 +1,95 @@
+# Grafana dashboards
+
+## MNA – Golden Flow dashboard
+
+This dashboard focuses on the Real MVP golden flow:
+
+> `Create meeting → upload MP4 → RQ/Redis → process_meeting → meeting_notes row in Postgres`
+
+### Importing the dashboard
+
+1. In Grafana, go to **Dashboards → New → Import**.
+2. Either:
+   - Paste the JSON from `docs/grafana/mna-golden-flow.json`, **or**
+   - Upload the file directly.
+3. When prompted, select your **Prometheus** datasource (or map `PROMETHEUS_DS` to the correct one).
+4. Click **Import**.
+
+### Panels and how to use them
+
+#### HTTP request rate by status / path
+
+- **Panels:**
+  - `HTTP request rate by status (api)`
+  - `HTTP request rate by path (api)`
+- **Queries:**
+  - `sum by (status) (rate(http_requests_total{service="api"}[5m]))`
+  - `topk(10, sum by (path) (rate(http_requests_total{service="api"}[5m])))`
+- **Use when:**
+  - You suspect **lots of errors** or unusual traffic patterns.
+  - Debugging "**lots of 5xx errors**".
+- **Typical flow:**
+  - If the 5xx series spikes, check:
+    - Recent deploys/config changes.
+    - `/healthz` and application logs.
+    - DB/Redis/MinIO health if 5xx correlate with dependency issues.
+
+#### HTTP latency P95/P99
+
+- **Panel:** `HTTP latency P95/P99 (api)`
+- **Queries:**
+  - `histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{service="api"}[5m])))`
+  - `histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{service="api"}[5m])))`
+- **Use when:**
+  - Investigating "**Real MVP is slow**".
+- **Typical flow:**
+  - If P95/P99 latency rises:
+    - Check DB load (slow queries, locks).
+    - Check Redis/MinIO latency or network issues.
+    - Look for spikes in request rate.
+    - Compare with RQ job throughput: slow jobs might block resources.
+
+#### RQ jobs: throughput & failures
+
+- **Panels:**
+  - `RQ jobs enqueued/completed/failed (rate, all queues)`
+  - `Failed jobs (last 15m, by job_name)`
+- **Queries:**
+  - `sum by (queue) (rate(mna_jobs_enqueued_total[5m]))`
+  - `sum by (queue) (rate(mna_jobs_completed_total[5m]))`
+  - `sum by (queue) (rate(mna_jobs_failed_total[5m]))`
+  - `sum by (job_name) (increase(mna_jobs_failed_total[15m]))`
+- **Use when:**
+  - Debugging "**jobs are stuck**" or "**lots of job failures**".
+- **Typical flow:**
+  - If `failed` lines spike or the failed-jobs panel highlights a job:
+    - Grab `job_name` and `queue`.
+    - Use worker logs (structured logs with `job_id`, `queue`, `job_name`) to find root cause.
+    - Check if a recent deploy broke the job's code or dependencies.
+
+#### Queue health & backlog
+
+- **Panels:**
+  - `RQ queue depth (by queue)`
+  - `RQ backlog proxy (enqueued - completed rate, default queue)`
+- **Queries:**
+  - `sum by (queue) (mna_jobs_queue_depth)`
+  - `sum(rate(mna_jobs_enqueued_total{queue="default"}[5m])) - sum(rate(mna_jobs_completed_total{queue="default"}[5m]))`
+- **Use when:**
+  - Debugging "**jobs are stuck**" or slow note generation.
+- **Typical flow:**
+  - If `queue_depth` stays high and backlog rate is positive:
+    - Check `RQ worker` container health.
+    - Look for very slow jobs (long processing time).
+    - Consider scaling workers or splitting queues.
+
+#### Worker / service health
+
+- **Panel:** `Service health (up)`
+- **Query:** `sum by (job) (up{job=~"api|worker"})`
+- **Use when:**
+  - Checking if the **api** or **worker** Prometheus target is up.
+- **Typical flow:**
+  - If `up{job="worker"}` or `up{job="api"}` drops:
+    - Check `./bin/dc ps` and `./bin/dc logs <service>`.
+    - Verify container restarts, OOM kills, or crash loops.

--- a/docs/grafana/mna-golden-flow.json
+++ b/docs/grafana/mna-golden-flow.json
@@ -1,0 +1,347 @@
+{
+  "id": null,
+  "uid": "mna-golden-flow",
+  "title": "MNA \u2013 Golden Flow",
+  "tags": [
+    "meeting-notes-assistant",
+    "mna",
+    "golden-flow"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 36,
+  "version": 1,
+  "refresh": "15s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "HTTP request rate by status (api)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROMETHEUS_DS"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (status) (rate(http_requests_total{service=\"api\"}[5m]))",
+          "legendFormat": "{{status}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "HTTP request rate by path (api)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROMETHEUS_DS"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "topk(10, sum by (path) (rate(http_requests_total{service=\"api\"}[5m])))",
+          "legendFormat": "{{path}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "HTTP latency P95/P99 (api)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROMETHEUS_DS"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{service=\"api\"}[5m])))",
+          "legendFormat": "p95"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{service=\"api\"}[5m])))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "RQ jobs enqueued/completed/failed (rate, all queues)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROMETHEUS_DS"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (queue) (rate(mna_jobs_enqueued_total[5m]))",
+          "legendFormat": "enqueued {{queue}}"
+        },
+        {
+          "refId": "B",
+          "expr": "sum by (queue) (rate(mna_jobs_completed_total[5m]))",
+          "legendFormat": "completed {{queue}}"
+        },
+        {
+          "refId": "C",
+          "expr": "sum by (queue) (rate(mna_jobs_failed_total[5m]))",
+          "legendFormat": "failed {{queue}}"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Failed jobs (last 15m, by job_name)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROMETHEUS_DS"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (job_name) (increase(mna_jobs_failed_total[15m]))",
+          "legendFormat": "{{job_name}}"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "RQ queue depth (by queue)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROMETHEUS_DS"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 16
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (queue) (mna_jobs_queue_depth)",
+          "legendFormat": "{{queue}}"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Service health (up)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROMETHEUS_DS"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 16
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (job) (up{job=~\"api|worker\"})",
+          "legendFormat": "{{job}}"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "RQ backlog proxy (enqueued - completed rate, default queue)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROMETHEUS_DS"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(mna_jobs_enqueued_total{queue=\"default\"}[5m])) - sum(rate(mna_jobs_completed_total{queue=\"default\"}[5m]))",
+          "legendFormat": "default backlog rate"
+        }
+      ]
+    }
+  ],
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  }
+}

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -82,3 +82,92 @@ To confirm that the API is exposing Prometheus metrics, run:
 curl -f http://localhost:8000/metrics-prom | head
 
 You should see Prometheus-style text output (starting with '# HELP' / '# TYPE') and counters like 'http_requests_total' and histograms like 'http_request_duration_seconds'. In production, Prometheus should scrape the backend at '/metrics-prom' (for example 'http://backend:8000/metrics-prom' on the Docker network, or 'https://notes.example.com/metrics-prom' via your reverse proxy).
+
+## Alerts and runbooks
+
+### Where the alert rules live
+
+Prometheus alerting rules are checked into the repo at:
+
+- `prometheus/alerts.yml`
+
+They are loaded from `prometheus.yml` via:
+
+```yaml
+rule_files:
+  - "prometheus/alerts.yml"
+
+```
+
+When you update alerts, remember to reload Prometheus (or restart the container) so changes take effect.
+
+### API errors and latency
+
+Related alerts:
+
+- `Api5xxRateHigh`
+- `ApiLatencyHigh`
+
+First steps when these fire:
+
+1. **Check Grafana “MNA – Golden Flow” dashboard:**
+   - Look at:
+     - **HTTP request rate by status (api)** – is 5xx spiking?
+     - **HTTP latency P95/P99 (api)** – is latency high at the same time?
+2. **Check `/healthz`:**
+   - `curl -f http://backend:8000/healthz` or via the reverse proxy.
+   - If `/healthz` fails, the problem is likely DB/Redis/MinIO or the app itself.
+3. **Check logs:**
+   - API logs around the time of the alert.
+   - Worker logs if failures involve the real MVP path (`process_meeting`).
+4. **Look for recent changes:**
+   - New deploys, config changes, schema migrations.
+5. **If DB-bound:**
+   - Look for slow queries, locks, or connection exhaustion.
+   - Check for high CPU or I/O on the DB host.
+
+### RQ job failures and backlog
+
+Related alerts:
+
+- `RQJobFailuresHigh`
+- `RQQueueBacklogHigh`
+
+First steps when these fire:
+
+1. **Check Grafana:**
+   - **RQ jobs enqueued/completed/failed (rate, all queues)** – is `failed` spiking?
+   - **Failed jobs (last 15m, by job_name)** – which `job_name` is failing?
+   - **RQ queue depth (by queue)** and **RQ backlog proxy** – is there a backlog?
+2. **Inspect worker logs:**
+   - Use `job_name`, `queue`, and `job_id` from the metrics panel.
+   - Check structured logs from `ObservabilityWorker` for stack traces and context.
+3. **Look for systemic issues:**
+   - Broken external dependencies (e.g., ASR/OCR services).
+   - Schema changes that made existing jobs invalid.
+4. **Mitigation options:**
+   - Temporarily pause traffic or enqueueing if needed.
+   - Fix the underlying bug and redeploy.
+   - Manually re-queue or clean up failed jobs once fixed.
+
+### Worker down
+
+Related alert:
+
+- `RQWorkerDown`
+
+First steps when this fires:
+
+1. **Check Grafana “Service health (up)” panel:**
+   - Confirm `up{job="worker"}` is `0`.
+2. **Check the container:**
+   - `./bin/dc ps` – is the `worker` container unhealthy or restarting?
+   - `./bin/dc logs worker` – look for tracebacks, config errors, OOM kills.
+3. **Check dependencies:**
+   - Redis health (`./bin/dc logs redis`, `/healthz`).
+   - If Redis is down, worker won’t be able to fetch jobs.
+4. **Mitigate:**
+   - Fix the underlying cause (config, code, resource limits).
+   - Restart the worker: `./bin/dc up -d worker`.
+5. **After recovery:**
+   - Watch queue depth and job failure panels to ensure the backlog drains cleanly.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -28,3 +28,16 @@ Automate meeting note-taking: ingest audio/video + slides, transcribe, summarize
   - `curl -f http://localhost:8000/healthz`
   - `curl -s http://localhost:8000/metrics-prom | head`
 - Took a real logical backup of the `meetings` database using `pg_dump` and checked the `.sql` file into `backups/postgres/`.
+
+## `feat/obs-golden-flow-dashboard` (merged 2025-12-04)
+  - Added Grafana “MNA – Golden Flow” dashboard JSON (`docs/grafana/mna-golden-flow.json`)
+    to visualize the Real MVP path (HTTP traffic, latency, RQ job throughput, queue depth,
+    backlog proxy, and service health).
+  - Added `docs/grafana.md` with import instructions and panel-by-panel guidance for
+    debugging “Real MVP is slow”, “jobs are stuck”, and “lots of 5xx errors”.
+  - Added Prometheus alert rules (`prometheus/alerts.yml`) and local Prometheus config
+    (`prometheus/prometheus.yml` + `docker-compose.prometheus.yml`), validated via
+    `promtool check rules` inside the container.
+  - Extended `docs/observability.md` with an “Alerts and runbooks” section documenting
+    where rules live and first-response steps for API errors/latency, RQ job failures/backlog,
+    and worker down situations.

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -1,0 +1,79 @@
+groups:
+  - name: mna-api-alerts
+    rules:
+      - alert: Api5xxRateHigh
+        expr: >
+          sum(rate(http_requests_total{service="api",status=~"5.."}[5m]))
+          /
+          sum(rate(http_requests_total{service="api"}[5m]))
+          > 0.05
+          and
+          sum(rate(http_requests_total{service="api"}[5m])) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+          service: api
+        annotations:
+          summary: High rate of 5xx responses on the API
+          description: |
+            More than 5% of API responses have been 5xx for over 5 minutes.
+            Check /healthz, recent deploys, and application/worker logs.
+          runbook_url: https://github.com/drlalitasaharan/meeting-notes-assistant/blob/main/docs/observability.md#api-errors-and-latency
+
+      - alert: ApiLatencyHigh
+        expr: >
+          histogram_quantile(
+            0.95,
+            sum by (le) (rate(http_request_duration_seconds_bucket{service="api"}[5m]))
+          ) > 1
+        for: 5m
+        labels:
+          severity: warning
+          service: api
+        annotations:
+          summary: High API latency (P95 > 1s)
+          description: |
+            API 95th percentile latency is above 1s for 5 minutes.
+            Check for database hotspots, external dependencies, or spikes in traffic.
+          runbook_url: https://github.com/drlalitasaharan/meeting-notes-assistant/blob/main/docs/observability.md#api-errors-and-latency
+
+  - name: mna-rq-alerts
+    rules:
+      - alert: RQWorkerDown
+        expr: up{job="worker"} == 0
+        for: 5m
+        labels:
+          severity: critical
+          service: worker
+        annotations:
+          summary: RQ worker target is down
+          description: |
+            Prometheus reports the RQ worker as down for more than 5 minutes.
+            Jobs will not be processed until the worker is back up.
+          runbook_url: https://github.com/drlalitasaharan/meeting-notes-assistant/blob/main/docs/observability.md#worker-down
+
+      - alert: RQJobFailuresHigh
+        expr: sum by (queue) (rate(mna_jobs_failed_total[5m])) > 0.1
+        for: 10m
+        labels:
+          severity: warning
+          service: worker
+        annotations:
+          summary: High rate of failed RQ jobs
+          description: |
+            RQ job failures are above 0.1 failures/second for at least one queue
+            over 10 minutes. Inspect job logs (job_name, queue) and recent deploys.
+          runbook_url: https://github.com/drlalitasaharan/meeting-notes-assistant/blob/main/docs/observability.md#rq-job-failures-and-backlog
+
+      - alert: RQQueueBacklogHigh
+        expr: sum by (queue) (mna_jobs_queue_depth) > 100
+        for: 10m
+        labels:
+          severity: warning
+          service: worker
+        annotations:
+          summary: RQ queue backlog is high
+          description: |
+            At least one RQ queue has more than 100 jobs queued for over 10 minutes.
+            Check worker capacity, job duration, and recent deploys.
+          runbook_url: https://github.com/drlalitasaharan/meeting-notes-assistant/blob/main/docs/observability.md#rq-job-failures-and-backlog

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,22 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - "alerts.yml"
+
+scrape_configs:
+  - job_name: "api"
+    metrics_path: /metrics-prom
+    static_configs:
+      - targets: ["backend:8000"]
+        labels:
+          service: api
+
+  # Optional: enable this if your worker exposes Prometheus metrics
+  # - job_name: "worker"
+  #   metrics_path: /metrics-prom
+  #   static_configs:
+  #     - targets: ["worker:8000"]
+  #       labels:
+  #         service: worker


### PR DESCRIPTION
obs: golden flow dashboard, alerts, and prometheus

- Add Grafana “MNA – Golden Flow” dashboard JSON (docs/grafana/mna-golden-flow.json)
  to visualize the Real MVP path: HTTP traffic, latency, RQ job throughput, queue
  depth, backlog proxy, and service health.
- Add docs/grafana.md documenting how to import the dashboard into Grafana and how
  to use each panel when debugging “Real MVP is slow”, “jobs are stuck”, or
  “lots of 5xx errors”.
- Add Prometheus alert rules in prometheus/alerts.yml for:
  - Api5xxRateHigh (API 5xx rate)
  - ApiLatencyHigh (P95 latency)
  - RQWorkerDown (worker Prometheus target down)
  - RQJobFailuresHigh (failed-job rate)
  - RQQueueBacklogHigh (queue depth)
- Extend docs/observability.md with an “Alerts and runbooks” section documenting
  where rules live (prometheus/alerts.yml) and first-response steps for API
  errors/latency, RQ job failures/backlog, and worker down situations.
- Record the observability milestone in docs/prd.md under
  `feat/obs-golden-flow-dashboard` to capture the final 5% of prod-ready SRE/obs
  polish for the Real MVP flow.
