### PR TITLE
Upgrade meeting notes generation to strategy-based local summarization

### DIFF
--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -9,9 +9,15 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://redis:6379/0"
     RQ_QUEUE: str = "default"
 
+    # Notes strategy
+    NOTES_STRATEGY: str = "local_summary"
+    NOTES_FALLBACK_STRATEGY: str = "local_summary"
+
     # LLM
     OPENAI_API_KEY: str | None = None
     LLM_MODEL: str = "gpt-4o-mini"
+    LLM_PROVIDER: str | None = None
+    OPENAI_MODEL: str = "gpt-4.1-mini"
 
     # MinIO (optional)
     MINIO_ENDPOINT: str | None = None
@@ -20,7 +26,14 @@ class Settings(BaseSettings):
     MINIO_USE_SSL: bool = False
     SLIDES_BUCKET: str = "meeting-slides"
 
-    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        extra="ignore",
+    )
 
 
 settings = Settings()
+
+
+def get_settings() -> Settings:
+    return settings

--- a/backend/app/jobs/process_meeting.py
+++ b/backend/app/jobs/process_meeting.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 from rq import get_current_job
 from sqlalchemy.orm import Session
 
+from app.core.settings import settings
 from app.db import SessionLocal
 from app.models.meeting import Meeting
 from app.models.meeting_notes import MeetingNotes
 from app.services.media import load_audio_for_meeting
+from app.services.note_strategies.factory import get_notes_strategy
 from app.services.notes import generate_meeting_notes
 from app.services.ocr import extract_slide_text_for_meeting
 from app.services.transcription import transcribe_audio
@@ -19,15 +22,17 @@ log = logging.getLogger(__name__)
 
 def process_meeting(meeting_id: str) -> None:
     """
-    Golden-path meeting processing job (DB + notes persistence).
+    Golden-path meeting processing job.
 
-    Current v0 behaviour:
+    Current behaviour:
       - Loads Meeting from DB
       - Marks status PROCESSING -> DONE / ERROR
-      - Uses stub media/transcription/LLM helpers
-      - Persists a MeetingNotes row with structured notes
-
-    Storage and real transcription/LLM are still stubbed and will be wired next.
+      - Reads the real uploaded media from meeting.raw_media_path
+      - Extracts audio bytes via app.services.media.load_audio_for_meeting
+      - Transcribes audio locally
+      - Optionally enriches transcript with slide OCR
+      - Generates notes
+      - Persists a MeetingNotes row
     """
     job = get_current_job()
     job_id = job.id if job is not None else None
@@ -39,31 +44,47 @@ def process_meeting(meeting_id: str) -> None:
     try:
         db = SessionLocal()
 
-        # 1) Load meeting
-        meeting = db.get(Meeting, meeting_id)
-        if meeting is None:
-            log.error("process_meeting: meeting not found", extra=log_extra)
-            return
+        meeting_pk = int(meeting_id)
 
-        # 2) Mark as PROCESSING (if status field exists)
+        # 1) Load meeting
+        meeting = db.get(Meeting, meeting_pk)
+        if meeting is None:
+            raise RuntimeError(f"Meeting {meeting_id} not found in worker database")
+
+        # 2) Mark as PROCESSING
         if hasattr(meeting, "status"):
             meeting.status = "PROCESSING"
         if hasattr(meeting, "last_error"):
-            setattr(meeting, "last_error", None)
+            meeting.last_error = None
 
         db.commit()
         db.refresh(meeting)
 
-        # 3) Media → audio (still stubbed)
-        fake_video_bytes = b"stub-video"  # later: fetch from MinIO using raw_media_path
-        log.info("process_meeting: loading audio", extra=log_extra)
-        audio_bytes = load_audio_for_meeting(meeting_id, fake_video_bytes)
+        # 3) Read real uploaded media from saved path
+        raw_media_path = getattr(meeting, "raw_media_path", None)
+        if not raw_media_path:
+            raise RuntimeError(f"Meeting {meeting.id} has no raw_media_path")
+
+        if not os.path.exists(raw_media_path):
+            raise RuntimeError(
+                f"Raw media file not found for meeting {meeting.id}: {raw_media_path}"
+            )
+
+        log.info(
+            "process_meeting: loading audio",
+            extra={**log_extra, "raw_media_path": raw_media_path},
+        )
+
+        with open(raw_media_path, "rb") as f:
+            media_bytes = f.read()
+
+        audio_bytes = load_audio_for_meeting(str(meeting.id), media_bytes)
 
         # 4) Transcription
         log.info("process_meeting: transcribing audio", extra=log_extra)
         transcript = transcribe_audio(audio_bytes)
 
-        # 4a) Optional slide OCR to enrich transcript
+        # 4a) Optional slide OCR enrichment
         log.info("process_meeting: running slide OCR", extra=log_extra)
         slide_text = extract_slide_text_for_meeting(
             db=db,
@@ -71,18 +92,26 @@ def process_meeting(meeting_id: str) -> None:
         )
 
         if slide_text:
-            # Ensure transcript is a mutable dict
             if not isinstance(transcript, dict):
                 transcript = dict(transcript)  # type: ignore[arg-type]
             transcript["slide_text"] = slide_text  # type: ignore[index]
 
-        # 5) LLM summarization
+        # 5) Generate notes
         log.info("process_meeting: generating notes", extra=log_extra)
-        notes_dict = generate_meeting_notes(transcript)
+
+        notes_strategy_name = getattr(settings, "NOTES_STRATEGY", "local_summary")
+
+        if notes_strategy_name == "local_rules":
+            notes_dict = generate_meeting_notes(transcript)
+        else:
+            transcript_text = str(transcript.get("text", "") or "")
+            slide_text = str(transcript.get("slide_text", "") or "")
+            notes_result = get_notes_strategy().generate(transcript_text, slide_text)
+            notes_dict = notes_result.to_api_dict()
 
         # 6) Persist MeetingNotes row
         notes_row = MeetingNotes(
-            meeting_id=str(meeting.id),
+            meeting_id=meeting.id,
             raw_transcript=transcript,
             summary=notes_dict.get("summary") or "",
             key_points=notes_dict.get("key_points") or [],
@@ -95,7 +124,7 @@ def process_meeting(meeting_id: str) -> None:
         if hasattr(meeting, "status"):
             meeting.status = "DONE"
         if hasattr(meeting, "last_error"):
-            setattr(meeting, "last_error", None)
+            meeting.last_error = None
 
         db.commit()
 
@@ -103,24 +132,32 @@ def process_meeting(meeting_id: str) -> None:
             "process_meeting: finished",
             extra={**log_extra, "summary_preview": notes_dict.get("summary", "")[:80]},
         )
+
     except Exception as exc:
         log.exception("process_meeting: error", extra=log_extra)
 
         if db is not None:
             try:
                 db.rollback()
-                meeting = db.get(Meeting, meeting_id)
-                if meeting is not None and hasattr(meeting, "status"):
-                    meeting.status = "ERROR"
-                    if hasattr(meeting, "last_error"):
-                        msg = str(exc)
-                        setattr(meeting, "last_error", msg[:250])
-                    db.commit()
+
+                try:
+                    meeting_pk = int(meeting_id)
+                except ValueError:
+                    meeting_pk = None
+
+                if meeting_pk is not None:
+                    meeting = db.get(Meeting, meeting_pk)
+                    if meeting is not None:
+                        if hasattr(meeting, "status"):
+                            meeting.status = "ERROR"
+                        if hasattr(meeting, "last_error"):
+                            meeting.last_error = str(exc)[:250]
+                        db.commit()
             except Exception:
                 db.rollback()
 
-        # Re-raise so callers / RQ can see failure
         raise
+
     finally:
         if db is not None:
             db.close()

--- a/backend/app/models/meeting_notes.py
+++ b/backend/app/models/meeting_notes.py
@@ -10,7 +10,7 @@ class MeetingNotes(Base):
 
     id = Column(Integer, primary_key=True)
     meeting_id = Column(
-        String,
+        Integer,
         ForeignKey("meetings.id", ondelete="CASCADE"),
         nullable=False,
     )

--- a/backend/app/routers/notes_api.py
+++ b/backend/app/routers/notes_api.py
@@ -1,7 +1,7 @@
 # backend/app/routers/notes_api.py
 import logging
 import os
-from typing import Optional
+from typing import Optional, cast
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
@@ -131,7 +131,10 @@ def create_note(meeting_id: int, payload: NoteIn):
                 author=payload.author,
             )
         )
-        new_id = res.inserted_primary_key[0]
+        inserted_pk = cast(tuple[object, ...] | None, res.inserted_primary_key)
+        if not inserted_pk or inserted_pk[0] is None:
+            raise HTTPException(status_code=500, detail="failed to create note")
+        new_id = inserted_pk[0]
         row = (
             conn.execute(
                 select(

--- a/backend/app/services/note_strategies/__init__.py
+++ b/backend/app/services/note_strategies/__init__.py
@@ -1,0 +1,13 @@
+from .base import ActionItem, NotesResult, NotesStrategy
+from .factory import get_notes_strategy
+from .llm_summary import LLMSummaryStrategy
+from .local_summary import LocalSummaryStrategy
+
+__all__ = [
+    "ActionItem",
+    "NotesResult",
+    "NotesStrategy",
+    "LocalSummaryStrategy",
+    "LLMSummaryStrategy",
+    "get_notes_strategy",
+]

--- a/backend/app/services/note_strategies/base.py
+++ b/backend/app/services/note_strategies/base.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class ActionItem:
+    owner: Optional[str]
+    task: str
+    due: Optional[str] = None
+    confidence: float = 0.0
+
+    def to_legacy_string(self) -> str:
+        parts: list[str] = []
+        if self.owner:
+            parts.append(self.owner)
+        parts.append(self.task)
+
+        text = " — ".join(parts)
+        if self.due:
+            text += f" (due: {self.due})"
+        return text
+
+
+@dataclass
+class NotesResult:
+    summary: str
+    key_points: List[str] = field(default_factory=list)
+    action_items: List[ActionItem] = field(default_factory=list)
+    decisions: List[str] = field(default_factory=list)
+    model_version: str = "unknown"
+
+    def to_api_dict(self) -> dict:
+        return {
+            "summary": self.summary,
+            "key_points": self.key_points,
+            "action_items": [item.to_legacy_string() for item in self.action_items],
+            "action_item_objects": [asdict(item) for item in self.action_items],
+            "decisions": self.decisions,
+            "model_version": self.model_version,
+        }
+
+
+class NotesStrategy:
+    def generate(self, transcript_text: str, slide_text: str = "") -> NotesResult:
+        raise NotImplementedError

--- a/backend/app/services/note_strategies/factory.py
+++ b/backend/app/services/note_strategies/factory.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from app.core.settings import settings
+
+from .llm_summary import LLMSummaryStrategy
+from .local_summary import LocalSummaryStrategy
+
+
+def get_notes_strategy():
+    strategy = getattr(settings, "NOTES_STRATEGY", "local_summary")
+
+    if strategy == "llm":
+        return LLMSummaryStrategy()
+
+    return LocalSummaryStrategy()

--- a/backend/app/services/note_strategies/llm_summary.py
+++ b/backend/app/services/note_strategies/llm_summary.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from .base import NotesResult, NotesStrategy
+from .local_summary import LocalSummaryStrategy
+
+
+class LLMSummaryStrategy(NotesStrategy):
+    def generate(self, transcript_text: str, slide_text: str = "") -> NotesResult:
+        try:
+            raise NotImplementedError("LLM path not wired yet")
+        except Exception:
+            result = LocalSummaryStrategy().generate(transcript_text, slide_text)
+            result.model_version = "local-summary-v1-fallback"
+            return result

--- a/backend/app/services/note_strategies/local_summary.py
+++ b/backend/app/services/note_strategies/local_summary.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Literal
+
+from .base import ActionItem, NotesResult, NotesStrategy
+
+SourceType = Literal["transcript", "slide"]
+
+
+STOPWORDS = {
+    "the",
+    "a",
+    "an",
+    "and",
+    "or",
+    "but",
+    "to",
+    "of",
+    "in",
+    "on",
+    "for",
+    "is",
+    "are",
+    "was",
+    "were",
+    "it",
+    "that",
+    "this",
+    "with",
+    "as",
+    "at",
+    "by",
+    "we",
+    "you",
+    "they",
+    "he",
+    "she",
+    "i",
+    "our",
+    "their",
+    "be",
+    "from",
+    "will",
+    "would",
+    "should",
+    "could",
+    "can",
+    "have",
+    "has",
+    "had",
+    "not",
+    "if",
+    "then",
+    "than",
+    "so",
+    "do",
+    "does",
+    "did",
+    "done",
+}
+
+ACTION_VERBS = {
+    "send",
+    "share",
+    "prepare",
+    "review",
+    "update",
+    "draft",
+    "schedule",
+    "check",
+    "follow",
+    "create",
+    "fix",
+    "test",
+    "confirm",
+    "deliver",
+    "finalize",
+    "upload",
+    "document",
+    "investigate",
+    "call",
+    "verify",
+    "complete",
+    "move",
+    "deploy",
+    "implement",
+    "add",
+    "remove",
+    "refactor",
+    "improve",
+    "validate",
+    "publish",
+    "release",
+}
+
+CUE_PATTERNS = [
+    r"\bdecided\b",
+    r"\bdecision\b",
+    r"\baction item\b",
+    r"\baction items\b",
+    r"\bnext step\b",
+    r"\bnext steps\b",
+    r"\bowner\b",
+    r"\bdue\b",
+    r"\bdeadline\b",
+    r"\bwe need to\b",
+    r"\blet'?s\b",
+    r"\bshould\b",
+    r"\bwill\b",
+    r"\bgoing to\b",
+    r"\bfollow up\b",
+    r"\bagreed\b",
+]
+
+OWNER_PATTERNS = [
+    r"\b([A-Z][a-z]+)\s+will\s+",
+    r"\b([A-Z][a-z]+)\s+to\s+",
+    r"\bowner[:\-]\s*([A-Z][a-z]+)\b",
+]
+
+DUE_PATTERNS = [
+    r"\bby\s+([A-Za-z0-9 ,/_-]+)\b",
+    r"\b(tomorrow|next week|next month|monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b",
+]
+
+
+def normalize_text(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def split_sentences(text: str) -> list[str]:
+    if not text:
+        return []
+
+    normalized = normalize_text(text)
+
+    # keep bullets / slide lines useful
+    normalized = normalized.replace("•", ". ")
+    normalized = normalized.replace(" - ", ". ")
+    normalized = normalized.replace("\n", " ")
+
+    parts = re.split(r"(?<=[.!?])\s+", normalized)
+    return [part.strip() for part in parts if part.strip()]
+
+
+def build_sentence_records(transcript_text: str, slide_text: str) -> list[tuple[str, SourceType]]:
+    records: list[tuple[str, SourceType]] = []
+
+    for sentence in split_sentences(transcript_text):
+        records.append((sentence, "transcript"))
+
+    for sentence in split_sentences(slide_text):
+        records.append((sentence, "slide"))
+
+    return records
+
+
+def chunk_records(
+    records: list[tuple[str, SourceType]],
+    max_chars: int = 1800,
+) -> list[list[tuple[str, SourceType]]]:
+    chunks: list[list[tuple[str, SourceType]]] = []
+    current: list[tuple[str, SourceType]] = []
+    current_len = 0
+
+    for sentence, source in records:
+        if current and current_len + len(sentence) > max_chars:
+            chunks.append(current)
+            current = [(sentence, source)]
+            current_len = len(sentence)
+        else:
+            current.append((sentence, source))
+            current_len += len(sentence)
+
+    if current:
+        chunks.append(current)
+
+    return chunks
+
+
+def tokenize(text: str) -> list[str]:
+    return re.findall(r"[a-zA-Z0-9_-]+", text.lower())
+
+
+def word_freq(sentences: list[str]) -> Counter[str]:
+    counts: Counter[str] = Counter()
+    for sentence in sentences:
+        for word in tokenize(sentence):
+            if word not in STOPWORDS and len(word) > 2:
+                counts[word] += 1
+    return counts
+
+
+def sentence_score(sentence: str, freq: Counter[str], source: SourceType) -> float:
+    score = 0.0
+    lowered = sentence.lower()
+
+    for word in tokenize(sentence):
+        score += freq.get(word, 0)
+
+    for pattern in CUE_PATTERNS:
+        if re.search(pattern, lowered):
+            score += 8
+
+    if re.search(
+        r"\bby (monday|tuesday|wednesday|thursday|friday|tomorrow|next week|next month)\b",
+        lowered,
+    ):
+        score += 6
+
+    if ":" in sentence:
+        score += 1
+
+    # Slightly prefer transcript discussion over slide OCR
+    if source == "transcript":
+        score += 2
+    else:
+        score += 1
+
+    return score
+
+
+def dedupe_points(points: list[str]) -> list[str]:
+    seen = set()
+    out: list[str] = []
+
+    for point in points:
+        key = re.sub(r"[^a-z0-9]+", "", point.lower())
+        if key and key not in seen:
+            seen.add(key)
+            out.append(point)
+
+    return out
+
+
+def make_summary(points: list[str], max_points: int = 4) -> str:
+    top = points[:max_points]
+    if not top:
+        return "No substantial discussion could be summarized."
+    return " ".join(top)
+
+
+def extract_owner(sentence: str) -> str | None:
+    for pattern in OWNER_PATTERNS:
+        match = re.search(pattern, sentence)
+        if match:
+            return match.group(1)
+    return None
+
+
+def extract_due(sentence: str) -> str | None:
+    for pattern in DUE_PATTERNS:
+        match = re.search(pattern, sentence, re.IGNORECASE)
+        if match:
+            return match.group(1)
+    return None
+
+
+def looks_like_action(sentence: str) -> bool:
+    lowered = sentence.lower().strip()
+
+    strong_patterns = [
+        r"\bneed to\b",
+        r"\bneeds to\b",
+        r"\bshould\b",
+        r"\blet'?s\b",
+        r"\baction item\b",
+        r"\baction items\b",
+        r"\bnext step\b",
+        r"\bnext steps\b",
+        r"\bfollow up\b",
+        r"\bto do\b",
+        r"\bowner\b",
+        r"\bby (monday|tuesday|wednesday|thursday|friday|tomorrow|next week|next month)\b",
+    ]
+
+    if any(re.search(pattern, lowered) for pattern in strong_patterns):
+        return True
+
+    owner_future_patterns = [
+        r"\b[A-Z][a-z]+\s+will\b",
+        r"\b[A-Z][a-z]+\s+to\b",
+    ]
+    if any(re.search(pattern, sentence) for pattern in owner_future_patterns):
+        return True
+
+    return False
+
+
+def looks_like_decision(sentence: str) -> bool:
+    lowered = sentence.lower()
+    return any(
+        phrase in lowered
+        for phrase in [
+            "we decided",
+            "decision",
+            "agreed to",
+            "it was decided",
+            "we will proceed with",
+            "approved",
+            "we chose",
+        ]
+    )
+
+
+def extract_action_items(records: list[tuple[str, SourceType]]) -> list[ActionItem]:
+    items: list[ActionItem] = []
+
+    for sentence, source in records:
+        if not looks_like_action(sentence):
+            continue
+
+        owner = extract_owner(sentence)
+        due = extract_due(sentence)
+        confidence = 0.35
+
+        if owner:
+            confidence += 0.25
+        if due:
+            confidence += 0.20
+        if re.search(
+            r"\b(action item|action items|next step|next steps|follow up)\b",
+            sentence,
+            re.IGNORECASE,
+        ):
+            confidence += 0.20
+        if source == "transcript":
+            confidence += 0.05
+
+        items.append(
+            ActionItem(
+                owner=owner,
+                task=sentence.strip(),
+                due=due,
+                confidence=min(confidence, 0.95),
+            )
+        )
+
+    deduped: list[ActionItem] = []
+    seen = set()
+    for item in sorted(items, key=lambda x: x.confidence, reverse=True):
+        key = re.sub(r"[^a-z0-9]+", "", item.task.lower())
+        if key not in seen:
+            seen.add(key)
+            deduped.append(item)
+
+    return deduped[:8]
+
+
+def extract_decisions(records: list[tuple[str, SourceType]]) -> list[str]:
+    decisions = [sentence.strip() for sentence, _source in records if looks_like_decision(sentence)]
+    return dedupe_points(decisions)[:5]
+
+
+class LocalSummaryStrategy(NotesStrategy):
+    def generate(self, transcript_text: str, slide_text: str = "") -> NotesResult:
+        transcript_text = normalize_text(transcript_text)
+        slide_text = normalize_text(slide_text)
+
+        if not transcript_text and not slide_text:
+            return NotesResult(
+                summary="No transcript or slide content available.",
+                key_points=[],
+                action_items=[],
+                decisions=[],
+                model_version="local-summary-v1",
+            )
+
+        records = build_sentence_records(transcript_text, slide_text)
+        chunks = chunk_records(records, max_chars=1800)
+
+        all_points: list[str] = []
+        for chunk in chunks:
+            sentences = [sentence for sentence, _source in chunk]
+            freq = word_freq(sentences)
+            ranked = sorted(
+                chunk,
+                key=lambda item: sentence_score(item[0], freq, item[1]),
+                reverse=True,
+            )
+            all_points.extend([sentence for sentence, _source in ranked[:3]])
+
+        key_points = dedupe_points(all_points)[:8]
+        action_items = extract_action_items(records)
+        decisions = extract_decisions(records)
+        summary = make_summary(key_points, max_points=4)
+
+        return NotesResult(
+            summary=summary,
+            key_points=key_points,
+            action_items=action_items,
+            decisions=decisions,
+            model_version="local-summary-v1",
+        )


### PR DESCRIPTION
## Summary
This PR upgrades meeting notes generation from the older simple local rules path to a stronger local summary strategy, while preserving a fallback path.

## What changed
- added `backend/app/services/note_strategies/`
  - `base.py`
  - `local_summary.py`
  - `llm_summary.py`
  - `factory.py`
- wired `process_meeting` to choose strategy via `NOTES_STRATEGY`
- preserved legacy `generate_meeting_notes` as the `local_rules` fallback path
- added stronger local summarization with:
  - transcript normalization
  - sentence chunking
  - scoring/ranking
  - transcript + slide text support
- tightened action-item extraction to reduce false positives
- added notes strategy settings in `backend/app/core/settings.py`
- fixed `MeetingNotes.meeting_id` to align with integer `Meeting.id`
- improved `process_meeting` to read real uploaded media from `raw_media_path`
- improved worker-side meeting error handling

## Manual validation
- Created a fresh meeting
- Uploaded `test_speech.aiff`
- Worker completed processing successfully
- Verified `/v1/meetings/4/notes/ai` returned:
  - `status: "DONE"`
  - `model_version: "local-summary-v1"`
  - populated `summary`
  - populated `key_points`
  - `action_items: []` for non-action speech, confirming cleaner action-item extraction

## Example response
```json
{
  "action_items": [],
  "key_points": [
    "Hello, this is a real speech test for the meeting notes assistant.",
    "We are checking whether local whisper can transcribe this audio correctly."
  ],
  "meeting_id": 4,
  "model_version": "local-summary-v1",
  "status": "DONE",
  "summary": "Hello, this is a real speech test for the meeting notes assistant. We are checking whether local whisper can transcribe this audio correctly."
}


## Notes
- legacy `local_rules` path remains available through config
- LLM path is scaffolded as a fallback wrapper and can be wired later
- Alembic migration cleanup is still pending separately