### PR TITLE
Add demo readiness and pilot packaging docs

### DIFF
--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -1,0 +1,43 @@
+# Demo Readiness and Pilot Packaging
+
+This folder contains the demo and pilot-readiness package for Meeting Notes Assistant.
+
+## Goal
+
+Make the product easy to demonstrate, test, explain, and hand off during early pilot conversations.
+
+## Current product position
+
+Meeting Notes Assistant converts meeting recordings into structured notes with:
+
+- Summary
+- Purpose
+- Outcome
+- Risks
+- Next steps
+- Key points
+- Decisions
+- Action items
+
+## Current strongest supported claim
+
+The product currently performs best on short, structured business meetings.
+
+## Current safety position
+
+Non-meeting or narrative audio should not produce fake decisions, action items, or next steps.
+
+## Protected baselines
+
+The current quality and safety gates are protected by automated regression tests:
+
+- Meeting 81: real-meeting quality baseline
+- Meeting 86: non-meeting / narrative safety baseline
+
+## Demo package contents
+
+- runbook.md
+- pilot_package_checklist.md
+- sample_input_output_pack.md
+- demo_success_criteria.md
+- troubleshooting.md

--- a/docs/demo/demo_success_criteria.md
+++ b/docs/demo/demo_success_criteria.md
@@ -1,0 +1,49 @@
+# Demo Success Criteria
+
+## Technical success
+
+The demo is technically successful if:
+
+- Backend health check passes
+- Upload succeeds
+- Worker processes the file
+- Job reaches succeeded state
+- AI notes endpoint returns structured JSON
+- Markdown export is available
+- No backend crash occurs
+- No manual database fix is needed
+
+## Output quality success
+
+The output is successful if:
+
+- Summary is relevant and concise
+- Purpose is meaningful for a real meeting
+- Outcome is meaningful for a real meeting
+- Risks are not hallucinated
+- Next steps are actionable
+- Decisions are actual decisions
+- Action items are real tasks
+- Owner/due date fields are not invented when absent
+- Greeting noise is not promoted as a key point
+- Malformed transcript fragments are not shown as action items
+
+## Safety success
+
+The safety behavior is successful if:
+
+- Non-meeting audio does not produce fake structured decisions
+- Non-meeting audio does not produce fake action items
+- Narrative audio does not produce fake next steps
+- The system avoids overclaiming when audio is not a real meeting
+
+## Current launch-safe claim
+
+Use:
+
+Best for short, structured business meetings.
+
+Avoid:
+
+- Works perfectly for every meeting.
+- Fully replaces human review.

--- a/docs/demo/pilot_package_checklist.md
+++ b/docs/demo/pilot_package_checklist.md
@@ -1,0 +1,57 @@
+# Pilot Package Checklist
+
+## Product story
+
+Meeting Notes Assistant turns meeting recordings into structured notes, decisions, and action items so teams can reduce manual note-taking and preserve follow-through.
+
+## Recommended early pilot users
+
+- Consultants
+- Agencies
+- Startup operators
+- Founders
+- Client-service teams
+- Teams with recurring weekly syncs
+
+## Demo assets
+
+Prepare:
+
+- One short structured meeting audio file
+- One clean AI JSON output
+- One markdown notes export
+- One screenshot of the result page
+- One short explanation of the workflow
+
+## Workflow explanation
+
+1. Upload a meeting recording
+2. Review structured AI notes
+3. Export or copy the markdown-ready output
+
+## Quality baselines
+
+Internal references:
+
+- Meeting 81 is the real-meeting quality baseline
+- Meeting 86 is the non-meeting safety baseline
+
+## Safety positioning
+
+Use:
+
+The system is designed to avoid inventing meeting decisions or action items when the uploaded audio is not actually a meeting.
+
+Avoid:
+
+- The system is perfect.
+- The system works for every type of audio.
+- Human review is never needed.
+
+## Pilot feedback questions
+
+1. Would you use this after a real meeting?
+2. Which section is most useful: summary, decisions, or action items?
+3. What would make the output easier to trust?
+4. What would you need before using this with clients?
+5. Would markdown export be enough, or do you need Google Docs, Notion, or CRM export?

--- a/docs/demo/runbook.md
+++ b/docs/demo/runbook.md
@@ -1,0 +1,112 @@
+# Local Demo Runbook
+
+## 1. Start clean
+
+~~~bash
+cd /Users/lalitasaharan/Code/AJENCEL/meeting-notes-assistant || exit 1
+git checkout main
+git pull origin main
+git status
+~~~
+
+Expected:
+
+~~~text
+nothing to commit, working tree clean
+~~~
+
+## 2. Start services
+
+~~~bash
+./bin/dc up -d
+./bin/dc ps
+~~~
+
+Expected services:
+
+- backend
+- worker
+- postgres
+- redis
+- minio
+
+## 3. Check backend health
+
+~~~bash
+http :8000/healthz
+~~~
+
+Expected health status:
+
+~~~text
+status: ok
+~~~
+
+## 4. Create demo meeting
+
+~~~bash
+MEETING_ID=$(http --body POST :8000/v1/meetings title="Pilot Demo Meeting" | jq -r '.id')
+echo "$MEETING_ID"
+~~~
+
+## 5. Upload short demo audio
+
+Use a short, structured business-meeting file first.
+
+~~~bash
+http --form POST :8000/v1/meetings/$MEETING_ID/upload file@client_weekly_sync_10min.m4a
+~~~
+
+## 6. Watch worker logs
+
+~~~bash
+./bin/dc logs -f worker
+~~~
+
+Look for:
+
+- audio loaded
+- transcription completed
+- notes generated
+- job succeeded
+
+## 7. Check AI notes
+
+~~~bash
+http :8000/v1/meetings/$MEETING_ID/notes/ai | jq
+~~~
+
+Review:
+
+- summary
+- summary_slots
+- key_points
+- decisions
+- decision_objects
+- action_items
+- action_item_objects
+
+## 8. Check markdown export
+
+~~~bash
+http :8000/v1/meetings/$MEETING_ID/notes.md
+~~~
+
+## 9. Save latest demo output
+
+~~~bash
+mkdir -p test_outputs/demo
+http --body :8000/v1/meetings/$MEETING_ID/notes/ai > test_outputs/demo/latest_demo_notes_ai.json
+http --body :8000/v1/meetings/$MEETING_ID/notes.md > test_outputs/demo/latest_demo_notes.md
+~~~
+
+## 10. Readiness check
+
+Before showing externally, confirm:
+
+- Summary is concise and relevant
+- Purpose and outcome are present for real meetings
+- Decisions are real decisions
+- Action items are publishable tasks
+- Narrative/non-meeting content does not create fake actions
+- Greeting noise is not promoted into key points or action items

--- a/docs/demo/sample_input_output_pack.md
+++ b/docs/demo/sample_input_output_pack.md
@@ -1,0 +1,55 @@
+# Sample Input and Output Pack
+
+## Recommended sample input
+
+Use a short, structured business meeting recording.
+
+Ideal characteristics:
+
+- 5 to 10 minutes long
+- Clear English speech
+- One primary topic
+- Explicit decisions
+- Explicit next steps
+- At least one action item
+- Minimal background noise
+
+## Avoid for first demos
+
+Do not use these as first demo examples:
+
+- Long 60-minute narrative audio
+- Public-domain audiobook content
+- Very noisy recordings
+- Multiple overlapping speakers
+- Unstructured casual conversation
+- Audio with no business-meeting intent
+
+These are useful for safety testing, but not for first-impression demos.
+
+## Recommended output files
+
+For each demo sample, save:
+
+- AI JSON output
+- Markdown export
+- Optional screenshot from UI
+- Short human review note
+
+Recommended folder:
+
+~~~text
+test_outputs/demo/
+~~~
+
+Suggested names:
+
+~~~text
+latest_demo_notes_ai.json
+latest_demo_notes.md
+latest_demo_review.md
+~~~
+
+## External demo rule
+
+Only show outputs that pass human review.

--- a/docs/demo/troubleshooting.md
+++ b/docs/demo/troubleshooting.md
@@ -1,0 +1,74 @@
+# Demo Troubleshooting Guide
+
+## Backend health check fails
+
+~~~bash
+./bin/dc ps
+./bin/dc logs backend --tail=100
+./bin/dc restart backend
+http :8000/healthz
+~~~
+
+## Worker is not processing jobs
+
+~~~bash
+./bin/dc ps
+./bin/dc logs worker --tail=100
+./bin/dc restart worker
+~~~
+
+## Upload succeeds but notes are missing
+
+Check job status:
+
+~~~bash
+http :8000/v1/jobs/$JOB_ID | jq
+~~~
+
+Check worker logs:
+
+~~~bash
+./bin/dc logs -f worker
+~~~
+
+## MinIO or storage issue
+
+~~~bash
+http :8000/healthz | jq
+./bin/dc ps
+./bin/dc restart minio backend worker
+~~~
+
+## Notes quality looks weak
+
+Check:
+
+- Is the audio a real meeting?
+- Is it too long for the current demo?
+- Is speech clear?
+- Are there explicit decisions or action items?
+- Is the file closer to narrative/casual audio than business-meeting audio?
+
+For first demos, use a short structured meeting file.
+
+## Narrative audio creates fake meeting notes
+
+Run:
+
+~~~bash
+PYTHONPATH=backend pytest backend/tests/test_notes_quality_regression.py -q
+~~~
+
+Expected:
+
+~~~text
+2 passed
+~~~
+
+If this fails, do not use the branch for demos.
+
+## Demo rule
+
+Do not debug live in front of a pilot user unless the purpose of the call is technical validation.
+
+For a polished pilot conversation, use a pre-tested input and pre-reviewed output.


### PR DESCRIPTION
## Summary

Adds a demo readiness and pilot packaging documentation pack for Meeting Notes Assistant.

## What changed

Created `docs/demo/` with:

- `README.md`
- `runbook.md`
- `pilot_package_checklist.md`
- `sample_input_output_pack.md`
- `demo_success_criteria.md`
- `troubleshooting.md`

## Why this matters

The previous workstream added automated quality and safety regression gates for Meeting 81 and Meeting 86. This PR builds on that by documenting how to prepare and run a clean pilot/demo flow.

The goal is to make the product easier to demonstrate, explain, validate, and hand off during early pilot conversations.

## Key coverage

- Local demo runbook
- Pilot package checklist
- Recommended sample input/output pack
- Demo success criteria
- Troubleshooting guide
- Launch-safe product positioning
- Safety expectations for non-meeting/narrative audio

## Notes

This PR is documentation-only and does not change product code.