### PR TITLE
Add pilot outreach asset templates

### DIFF
--- a/docs/pilot/outreach_assets.md
+++ b/docs/pilot/outreach_assets.md
@@ -1,0 +1,248 @@
+# Pilot Outreach Assets
+
+This document contains early pilot outreach materials for Meeting Notes Assistant.
+
+## 1. One-page pilot offer
+
+### Product
+
+Meeting Notes Assistant turns meeting recordings into structured notes, decisions, and action items.
+
+### Target users
+
+Best early pilot users:
+
+- Consultants
+- Agencies
+- Startup founders
+- Client-service teams
+- Operators running recurring meetings
+- Teams that spend time cleaning up notes after calls
+
+### Problem
+
+After meetings, teams often lose time turning recordings or rough notes into useful follow-up material.
+
+Common pain points:
+
+- Manual note cleanup
+- Missed decisions
+- Unclear action items
+- Slow follow-up
+- Notes scattered across tools
+- Poor handoff after client calls
+
+### Pilot offer
+
+We are inviting a small group of early users to test Meeting Notes Assistant on real meeting workflows.
+
+The pilot focuses on:
+
+- Uploading a meeting recording
+- Reviewing structured AI notes
+- Checking summaries, decisions, and action items
+- Giving feedback on quality, trust, and workflow fit
+
+### Best-fit meeting type
+
+The current strongest use case is:
+
+Short, structured business meetings with clear discussion, decisions, and next steps.
+
+### Current safety position
+
+The system is designed to avoid inventing meeting decisions or action items when the uploaded audio is not actually a meeting.
+
+### Pilot success
+
+The pilot is successful if the user says the output is:
+
+- Useful
+- Clear
+- Time-saving
+- Easy to review
+- Accurate enough for follow-up
+- Better than manual cleanup
+
+## 2. Short founder/demo script
+
+Hi, I am building Meeting Notes Assistant.
+
+The goal is simple: help teams turn meeting recordings into structured notes, decisions, and action items without spending extra time cleaning up notes manually.
+
+The current version works best for short, structured business meetings.
+
+In the demo, I will show three steps:
+
+1. Upload a meeting recording.
+2. Let the system process the audio.
+3. Review the structured notes, including summary, outcome, decisions, and action items.
+
+What I am looking for in this pilot is honest feedback:
+
+- Is the output useful?
+- Would you trust it after a real meeting?
+- Which sections are most valuable?
+- What would make this ready for your workflow?
+
+This is an early pilot, so I am not positioning it as perfect. I am validating whether the output saves time and whether the workflow is useful enough to improve further with real users.
+
+## 3. Email outreach template
+
+Subject: Quick pilot idea for meeting notes
+
+Hi [Name],
+
+I am working on a product called Meeting Notes Assistant.
+
+It turns meeting recordings into structured notes, decisions, and action items so teams can reduce manual note-taking and follow up faster.
+
+I am currently looking for a few early pilot users who regularly run client calls, team syncs, or project meetings.
+
+The current version works best for short, structured business meetings.
+
+Would you be open to a quick 15 to 20 minute demo and feedback session?
+
+I would especially value your feedback on whether the notes are useful, trustworthy, and easy to use after a real meeting.
+
+Best,
+Lalita
+
+## 4. LinkedIn/message outreach template
+
+Hi [Name], I am building Meeting Notes Assistant, a tool that turns meeting recordings into structured notes, decisions, and action items.
+
+I am looking for a few early pilot users who run regular meetings or client calls.
+
+Would you be open to a short demo and feedback session? I am mainly looking to understand whether the output is useful enough for real follow-up workflows.
+
+## 5. Demo review template
+
+# Demo Review
+
+## Demo date
+
+## Person / company
+
+## Meeting type tested
+
+## Input length
+
+## Output reviewed
+
+- AI JSON
+- Markdown export
+- UI result page
+
+## Summary quality
+
+Rating: 1 to 5
+
+Notes:
+
+## Decisions quality
+
+Rating: 1 to 5
+
+Notes:
+
+## Action items quality
+
+Rating: 1 to 5
+
+Notes:
+
+## Trust level
+
+Would the user trust this output after a real meeting?
+
+Yes / No / Maybe
+
+Notes:
+
+## Most useful section
+
+- Summary
+- Purpose
+- Outcome
+- Decisions
+- Action items
+- Risks
+- Next steps
+
+## Biggest concern
+
+## Feature requests
+
+## Would they use it again?
+
+Yes / No / Maybe
+
+## Follow-up action
+
+## 6. Sample output explanation for prospects
+
+The output is organized into practical meeting sections:
+
+### Summary
+
+A short overview of what the meeting covered.
+
+### Purpose
+
+Why the meeting happened.
+
+### Outcome
+
+What the meeting aligned on or concluded.
+
+### Risks
+
+Potential blockers or concerns discussed in the meeting.
+
+### Next steps
+
+Follow-up steps that should happen after the meeting.
+
+### Decisions
+
+Explicit decisions made during the discussion.
+
+### Action items
+
+Tasks that someone should complete after the meeting.
+
+### Markdown export
+
+A clean text version that can be copied into tools like Notion, Google Docs, Slack, or a CRM.
+
+## 7. Qualification questions for pilot users
+
+Ask before or during the pilot:
+
+1. How often do you have meetings that need follow-up notes?
+2. Who currently writes or cleans up meeting notes?
+3. How long does that usually take?
+4. Which sections matter most to you: summary, decisions, or action items?
+5. Where would you want to send the output after the meeting?
+6. Would markdown export be enough for now?
+7. What would make the output trustworthy?
+8. What type of meeting should we test first?
+
+## 8. Internal positioning notes
+
+Use careful positioning:
+
+Good:
+
+- Best for short, structured business meetings.
+- Designed to reduce manual note cleanup.
+- Helps capture decisions and action items.
+- Early pilot focused on workflow validation.
+
+Avoid:
+
+- Perfect transcription.
+- Works for every meeting.
+- Fully replaces human review.
+- Guaranteed legal or compliance-ready notes.


### PR DESCRIPTION
## Summary

Adds early pilot outreach assets for Meeting Notes Assistant.

## What changed

Created `docs/pilot/outreach_assets.md` with:

- One-page pilot offer
- Short founder/demo script
- Email outreach template
- LinkedIn/message outreach template
- Demo review template
- Sample output explanation for prospects
- Pilot qualification questions
- Internal positioning notes

## Why this matters

The project now has quality/safety regression gates and demo readiness documentation. This PR adds the next layer: external-facing pilot materials that make it easier to approach early users, explain the product, and collect structured feedback.

## Notes

Documentation-only change. No product code, tests, database migrations, or runtime behavior changed.