### PR TITLE
Polish demo markdown export text cleanup

### DIFF
--- a/backend/app/routers/meeting_notes_api.py
+++ b/backend/app/routers/meeting_notes_api.py
@@ -1,6 +1,7 @@
 # mypy: ignore-errors
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any, List
 
@@ -131,6 +132,26 @@ def get_meeting_notes(
     }
 
 
+def _clean_publishable_markdown_text(text: str) -> str:
+    """Apply final lightweight cleanup before markdown export."""
+    if not text:
+        return text
+
+    cleaned = text
+
+    replacements = {
+        "I'd us to": "I'd like us to",
+        "I’d us to": "I’d like us to",
+    }
+    for old, new in replacements.items():
+        cleaned = cleaned.replace(old, new)
+
+    # Remove accidental spaces before punctuation in publishable notes.
+    cleaned = re.sub(r"[ \t]+([,.;:!?])", r"\1", cleaned)
+
+    return cleaned
+
+
 @router.get("/{meeting_id}/notes.md")
 def download_meeting_notes_markdown(
     meeting_id: int,
@@ -222,7 +243,7 @@ def download_meeting_notes_markdown(
         lines.append("- (none)")
     lines.append("")
 
-    md = "\n".join(lines)
+    md = _clean_publishable_markdown_text("\n".join(lines))
     filename = f"meeting_{meeting_id}_notes.md"
 
     headers = {

--- a/backend/tests/test_markdown_output_polish.py
+++ b/backend/tests/test_markdown_output_polish.py
@@ -1,0 +1,19 @@
+from app.routers.meeting_notes_api import _clean_publishable_markdown_text
+
+
+def test_clean_publishable_markdown_removes_spaces_before_punctuation() -> None:
+    text = "- Validate the pilot demo .\n- Share the backup output ."
+    cleaned = _clean_publishable_markdown_text(text)
+
+    assert "demo ." not in cleaned
+    assert "output ." not in cleaned
+    assert "demo." in cleaned
+    assert "output." in cleaned
+
+
+def test_clean_publishable_markdown_fixes_known_demo_phrase() -> None:
+    text = "I'd us to leave this meeting with a clear demo plan."
+    cleaned = _clean_publishable_markdown_text(text)
+
+    assert "I'd us to leave" not in cleaned
+    assert "I'd like us to leave" in cleaned


### PR DESCRIPTION
## Summary

Adds a lightweight final cleanup step for markdown note exports.

## What changed

- Added `_clean_publishable_markdown_text()` in `backend/app/routers/meeting_notes_api.py`
- Applies final markdown cleanup before returning `/notes.md`
- Removes accidental spaces before punctuation
- Fixes the known demo phrase `I'd us to` → `I'd like us to`
- Added regression tests for markdown cleanup behavior

## Why this matters

The first pilot rehearsal passed technically, but found small external-demo polish issues in the markdown output:

- Extra spaces before periods in action items
- A malformed phrase: `I'd us to leave...`

This patch keeps the fix narrow and focused on publishable markdown export quality before external pilot demos.

## Validation

Ran:

```bash
PYTHONPATH=backend pytest backend/tests/test_markdown_output_polish.py backend/tests/test_notes_quality_regression.py -q