### PR TITLE
Fix prodready Docker healthcheck configuration

### DIFF
--- a/docker-compose.prodready.yml
+++ b/docker-compose.prodready.yml
@@ -1,14 +1,14 @@
 services:
   db:
-    image: postgres:15-alpine
+    image: postgres:16-alpine
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_USER: ${POSTGRES_USER:-mna}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-mna_local_pw}
       POSTGRES_DB: ${POSTGRES_DB:-meetings}
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-meetings}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-mna} -d ${POSTGRES_DB:-meetings}"]
       interval: 5s
       timeout: 3s
       retries: 20
@@ -41,7 +41,7 @@ services:
       dockerfile: backend/Dockerfile
     environment:
       ENV: ${ENV:-dev}
-      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg2://postgres:postgres@db:5432/meetings}
+      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg2://mna:mna_local_pw@db:5432/meetings}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
       STORAGE_BACKEND: ${STORAGE_BACKEND:-s3}
       S3_ENDPOINT: ${S3_ENDPOINT:-http://minio:9000}
@@ -60,7 +60,7 @@ services:
       minio:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/healthz"]
+      test: ["CMD-SHELL", "python -c \"import json, urllib.request; data=json.load(urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=3)); raise SystemExit(0 if data.get('status') == 'ok' else 1)\""]
       interval: 5s
       timeout: 3s
       retries: 50
@@ -70,7 +70,7 @@ services:
       dockerfile: worker/Dockerfile
     environment:
       ENV: ${ENV:-dev}
-      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg2://postgres:postgres@db:5432/meetings}
+      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg2://mna:mna_local_pw@db:5432/meetings}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
       STORAGE_BACKEND: ${STORAGE_BACKEND:-s3}
       S3_ENDPOINT: ${S3_ENDPOINT:-http://minio:9000}


### PR DESCRIPTION
## Summary

Fixes the prod-ready Docker Compose configuration so the backend healthcheck reflects real application readiness instead of only checking that `/healthz` is reachable.

## Changes

- Updates prod-ready Postgres image from `postgres:15-alpine` to `postgres:16-alpine`.
- Aligns prod-ready default DB credentials with the existing local `pgdata` volume:
  - `POSTGRES_USER=mna`
  - `POSTGRES_PASSWORD=mna_local_pw`
  - `POSTGRES_DB=meetings`
- Updates backend `DATABASE_URL` default to use the matching `mna:mna_local_pw` credentials.
- Replaces the backend `curl` healthcheck with a Python JSON healthcheck that only passes when `/healthz` returns `"status": "ok"`.

## Validation

- Confirmed `docker compose -f docker-compose.prodready.yml config` passes.
- Recreated prod-ready DB, Redis, MinIO, and backend services.
- Confirmed backend Docker health became `healthy`.
- Confirmed container-local `/healthz` returned:
  - DB: ok
  - Redis: ok
  - Storage: ok
  - Overall status: ok
- Pre-commit hooks passed:
  - ruff
  - ruff format
  - mypy
  - end-of-file fixer
  - trailing whitespace

## Decision

This makes prod-ready backend health stricter and safer because Docker will no longer mark the backend healthy when the API process is up but one of its required dependencies is failing.