### PR TITLE
Add prodready compose config CI guard

### DIFF
--- a/.github/workflows/prodready-compose-config.yml
+++ b/.github/workflows/prodready-compose-config.yml
@@ -1,0 +1,43 @@
+name: Prodready Compose Config
+
+on:
+  pull_request:
+    paths:
+      - "docker-compose.prodready.yml"
+      - ".github/workflows/prodready-compose-config.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "docker-compose.prodready.yml"
+      - ".github/workflows/prodready-compose-config.yml"
+
+jobs:
+  validate-prodready-compose:
+    name: Validate prodready Docker Compose config
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Render prodready compose config
+        run: |
+          docker compose -f docker-compose.prodready.yml config >/tmp/mna_prodready_config.yml
+
+      - name: Assert prodready defaults are safe
+        run: |
+          grep -q "image: postgres:16-alpine" /tmp/mna_prodready_config.yml
+          grep -q "POSTGRES_USER: mna" /tmp/mna_prodready_config.yml
+          grep -q "POSTGRES_PASSWORD: mna_local_pw" /tmp/mna_prodready_config.yml
+          grep -q "postgresql+psycopg2://mna:mna_local_pw@db:5432/meetings" /tmp/mna_prodready_config.yml
+          grep -q "data=json.load" /tmp/mna_prodready_config.yml
+          grep -q "status') == 'ok'" /tmp/mna_prodready_config.yml
+
+      - name: Reject old unsafe backend healthcheck and DB defaults
+        run: |
+          ! grep -q 'postgres:15-alpine' docker-compose.prodready.yml
+          ! grep -q 'postgres:postgres@db:5432/meetings' docker-compose.prodready.yml
+          ! grep -q 'POSTGRES_USER:-postgres' docker-compose.prodready.yml
+          ! grep -q 'POSTGRES_PASSWORD:-postgres' docker-compose.prodready.yml
+          ! grep -q 'curl", "-f", "http://localhost:8000/healthz' docker-compose.prodready.yml


### PR DESCRIPTION
## Summary

Adds a GitHub Actions guard to validate the prod-ready Docker Compose configuration on PRs and pushes to main.

## Changes

- Adds `.github/workflows/prodready-compose-config.yml`.
- Runs `docker compose -f docker-compose.prodready.yml config` in CI.
- Verifies prod-ready defaults remain aligned with the validated configuration:
  - Postgres 16 image
  - `mna / mna_local_pw / meetings` DB defaults
  - backend `DATABASE_URL` uses matching DB credentials
  - backend healthcheck parses `/healthz` JSON and only passes when `status == ok`
- Rejects older unsafe defaults:
  - `postgres:15-alpine`
  - `postgres:postgres@db:5432/meetings`
  - old postgres default env values
  - old backend `curl -f /healthz` healthcheck

## Validation

- Confirmed workflow file was created.
- Confirmed local prod-ready compose config renders successfully.
- Ran the same CI assertions locally.
- Pre-commit hooks passed.

## Decision

This prevents future regressions where the prod-ready compose file could accidentally return to weaker healthchecks or mismatched database defaults.