### PR TITLE
Document CI workflow coverage

### DIFF
--- a/docs/ops/ci_workflows.md
+++ b/docs/ops/ci_workflows.md
@@ -1,0 +1,59 @@
+# CI workflow index
+
+This document summarizes the repository CI checks and what each one protects.
+
+## Prodready Compose Config
+
+Workflow file:
+
+- `.github/workflows/prodready-compose-config.yml`
+
+Purpose:
+
+- Validates that `docker-compose.prodready.yml` renders correctly.
+- Protects the prod-ready Docker Compose defaults from accidental regression.
+
+Runs on:
+
+- Pull requests that change `docker-compose.prodready.yml` or the workflow file.
+- Pushes to `main` that change `docker-compose.prodready.yml` or the workflow file.
+
+Protects:
+
+- Postgres image remains `postgres:16-alpine`.
+- Default database credentials remain aligned with the validated local/prodready setup.
+- Backend `DATABASE_URL` remains aligned with the DB credentials.
+- Backend healthcheck remains strict and checks `/healthz` JSON status.
+- Older weaker defaults are rejected.
+
+## Prodready Healthz Smoke Test
+
+Workflow file:
+
+- `.github/workflows/prodready-healthz-smoke-test.yml`
+
+Purpose:
+
+- Starts the prod-ready Docker Compose stack in GitHub Actions.
+- Verifies that the backend runtime health contract works, not only that the compose file renders.
+
+Runs on:
+
+- Pull requests that change backend code, worker code, `docker-compose.prodready.yml`, or the workflow file.
+- Pushes to `main` that change backend code, worker code, `docker-compose.prodready.yml`, or the workflow file.
+
+Protects:
+
+- Postgres, Redis, and MinIO can start as prod-ready dependencies.
+- Backend can build and start.
+- Backend Docker healthcheck becomes healthy.
+- `/healthz` returns top-level `status: ok`.
+- DB, Redis, and storage checks all return `status: ok`.
+
+## Operational note
+
+The config guard catches static compose regressions quickly.
+
+The healthz smoke test catches runtime regressions where the backend process starts but dependencies or health semantics are broken.
+
+Together, these checks protect the prod-ready baseline needed before external demos and pilot usage.


### PR DESCRIPTION
## Summary

Adds an operational index for the repository CI workflows.

## Changes

- Adds `docs/ops/ci_workflows.md`.
- Documents the purpose of the prodready compose config guard.
- Documents the purpose of the prodready healthz smoke test.
- Explains when each workflow runs.
- Explains what each workflow protects.
- Adds an operational note describing how the static config guard and runtime healthz smoke test work together.

## Validation

- Confirmed the document was created and previewed locally.
- Pre-commit hooks passed:
  - ruff
  - ruff format
  - mypy
  - end-of-file fixer
  - trailing whitespace
- Branch pushed successfully:
  - `docs/ci-workflow-index`

## Decision

This gives future maintainers a quick reference for what the CI checks protect before external demos and pilot usage.