### PR TITLE
Document Pilot RC1 release readiness

### DIFF
--- a/docs/releases/pilot_rc1_readiness.md
+++ b/docs/releases/pilot_rc1_readiness.md
@@ -1,0 +1,147 @@
+# Pilot RC1 release readiness
+
+Branch: release/pilot-rc1-readiness
+
+## Goal
+
+Freeze the current validated product state as the first controlled pilot release candidate.
+
+This release candidate is intended for a small, controlled pilot with real users. It is not positioned as a broad production launch.
+
+## Pilot RC1 scope
+
+Pilot RC1 includes:
+
+- Uploading a meeting recording
+- Processing the recording through the local stack
+- Generating structured notes
+- Exporting markdown notes
+- Exporting AI JSON notes
+- Using the validated 10-minute pilot-ready demo path
+- Using prodready Docker health checks
+- Using CI guards for prodready compose config and healthz smoke testing
+
+## Validated baseline
+
+The current main branch includes the following validated checkpoints:
+
+- External-ready 10-minute demo rehearsal
+- Client-facing demo rehearsal pack
+- Final demo go/no-go rehearsal
+- Prodready Docker healthcheck configuration fix
+- Prodready compose config CI guard
+- Prodready healthz smoke test workflow
+- CI workflow coverage documentation
+- Pilot-ready user flow rehearsal
+
+## Intended pilot audience
+
+The recommended first pilot audience is:
+
+- Consultants
+- Small agencies
+- Founders
+- Startup teams
+- Small internal teams with frequent meetings
+
+These users are a good fit because they usually have short, structured meetings and feel the pain of manual note-taking quickly.
+
+## Product positioning for Pilot RC1
+
+Recommended positioning:
+
+Meeting Notes Assistant converts short, structured business meetings into readable summaries, key points, decisions, and action items.
+
+Pilot RC1 should be presented as a controlled pilot, not as a fully mature enterprise meeting intelligence platform.
+
+## Explicit limitations
+
+Pilot RC1 should not be over-positioned.
+
+Known limitations:
+
+- Best suited for short, structured business meetings
+- Not yet positioned for messy 60-minute multi-speaker meetings
+- Not yet positioned as legal, compliance, or audit-grade notes
+- Human review is expected before external sharing
+- Accuracy should be evaluated by the user before relying on decisions or action items
+- Long audio and noisy recordings may still require additional quality passes
+
+## Pilot success metrics
+
+Track these metrics during the pilot:
+
+- Upload success rate
+- Processing completion rate
+- Time saved per meeting
+- Summary usefulness
+- Decision accuracy
+- Action item usefulness
+- Markdown shareability
+- Amount of human editing required
+- User willingness to use again
+- Number of repeated issues or failure patterns
+
+## Go criteria
+
+Pilot RC1 is acceptable for controlled pilot use if:
+
+- Upload and processing complete reliably
+- Markdown output is readable and shareable after light review
+- Required note sections are present
+- Decisions and action items are useful enough for real follow-up
+- No major hallucinated decisions or action items are found
+- Users understand that this is a reviewed pilot workflow
+
+## No-go criteria
+
+Pilot RC1 should not be expanded if:
+
+- Processing fails repeatedly
+- Markdown output requires heavy rewriting
+- Decisions or action items are materially wrong
+- The demo path becomes unstable
+- Users do not find the output useful after review
+- The product creates false confidence in unverified notes
+
+## Demo fallback plan
+
+If a live demo fails:
+
+1. Stop the live run calmly.
+2. Use the saved pilot-ready markdown artifact.
+3. Show the saved AI JSON output if needed.
+4. Explain that the product is in controlled pilot stage.
+5. Collect feedback instead of forcing the live path.
+6. Log the failure as a pilot learning item.
+
+## Recommended pilot workflow
+
+For each pilot user:
+
+1. Use a short structured meeting recording.
+2. Run upload and processing.
+3. Export markdown and AI JSON.
+4. Review the generated notes with the user.
+5. Ask what was useful, wrong, missing, or unclear.
+6. Record time saved and editing effort.
+7. Add findings to the pilot feedback tracker.
+
+## Release decision
+
+Pilot RC1 is ready to be used for a small controlled pilot.
+
+The recommended next step after this document is merged is to tag the main branch as:
+
+pilot-rc1
+
+## Follow-up work after Pilot RC1
+
+Recommended follow-up work:
+
+- Create a pilot feedback tracker
+- Reduce Docker build context using .dockerignore
+- Add more real-world test recordings
+- Improve long-meeting extraction quality
+- Add richer frontend review/edit flow
+- Create a simple pilot onboarding checklist


### PR DESCRIPTION

Adds the Pilot RC1 release readiness document to freeze the current validated product state for a small controlled pilot.

This document captures:
- Pilot RC1 scope and intended audience
- Current validated checkpoints from demo, CI, and prodready workflow work
- Product positioning for a controlled pilot
- Explicit limitations and human-review expectations
- Pilot success metrics
- Go / no-go criteria
- Demo fallback plan
- Recommended pilot workflow
- Follow-up work after Pilot RC1

The release decision states that the current product state is ready for a small controlled pilot, not a broad production launch.

Validation:
- Confirmed docs/releases/pilot_rc1_readiness.md exists
- Validated docker-compose.prodready.yml renders successfully
- Pre-commit hooks passed