### PR TITLE
Add Pilot RC1 client-facing extraction quality gate

### DIFF
--- a/docs/pilot/pilot_rc1_client_facing_quality_gate_baseline.md
+++ b/docs/pilot/pilot_rc1_client_facing_quality_gate_baseline.md
@@ -1,0 +1,50 @@
+# Pilot RC1 Client-Facing Extraction Quality Gate Baseline
+
+Date: 2026-04-27
+
+## Summary
+
+A focused client-facing extraction quality gate was added and tested against the 10-minute client weekly sync demo audio.
+
+The infrastructure path passed: backend health, meeting creation, audio upload, worker processing, notes JSON generation, and Markdown generation all completed successfully.
+
+The extraction quality gate did not pass, which confirms that the next workstream should focus on action-item and next-step recall rather than general infrastructure.
+
+## Observed Gate Result
+
+```text
+decision_count: 5
+action_count: 2
+next_steps_count: 1
+has_weekly_priority_action: False
+client_facing_score: 50
+CLIENT_FACING_REHEARSAL_REVIEW_NEEDED
+```
+
+## Quality Gaps Observed
+
+- Action recall is still below the client-facing threshold.
+- Next-step recall is still below the client-facing threshold.
+- The weekly-priority action was not captured as an action item.
+- A malformed decision fragment appeared in the Decisions section.
+- A false action owner was produced from phrase-like text.
+
+## Acceptance Target
+
+```text
+- decision_count >= 3
+- action_count >= 3
+- next_steps_count >= 3
+- has_weekly_priority_action is True
+- no malformed decisions
+- no false action owners
+- no bad next steps
+- no duplicate actions
+- client_facing_score >= 95
+```
+
+## Decision
+
+This branch commits the reusable quality gate and baseline evidence only.
+
+Production extraction logic should be improved in a separate focused patch after this gate is merged.

--- a/scripts/quality_gates/pilot_rc1_client_facing_gate.py
+++ b/scripts/quality_gates/pilot_rc1_client_facing_gate.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _norm(value: Any) -> str:
+    return re.sub(r"\s+", " ", str(value or "")).strip()
+
+
+def _action_key(item: dict[str, Any]) -> str:
+    owner = _norm(item.get("owner")).lower()
+    task = _norm(item.get("task")).lower()
+    task = re.sub(r"[^a-z0-9]+", " ", task).strip()
+    return f"{owner}:{task}"
+
+
+def evaluate(path: Path) -> int:
+    data = json.loads(path.read_text())
+
+    decisions = data.get("decision_objects") or []
+    actions = data.get("action_item_objects") or []
+    slots = data.get("summary_slots") or {}
+    next_steps = slots.get("next_steps") or []
+    key_points = data.get("key_points") or []
+
+    bad_decisions: list[Any] = []
+    bad_actions: list[Any] = []
+    bad_next_steps: list[Any] = []
+    bad_key_points: list[Any] = []
+    duplicate_actions: list[Any] = []
+
+    seen_actions: set[str] = set()
+    has_weekly_priority_action = False
+
+    for item in decisions:
+        text = _norm(item.get("text")).lower()
+        if text in {"and action items", "action items"} or text.startswith("and action"):
+            bad_decisions.append(item)
+
+    for item in actions:
+        owner = _norm(item.get("owner"))
+        task = _norm(item.get("task"))
+        task_lower = task.lower()
+
+        if "weekly priorities" in task_lower or "priority" in task_lower:
+            has_weekly_priority_action = True
+
+        if owner == "Team" and ":" in task:
+            bad_actions.append(item)
+        if "the purpose of today's meeting" in task_lower:
+            bad_actions.append(item)
+        if "keep the launch scope focused on upload" in task_lower:
+            bad_actions.append(item)
+        if task_lower.startswith("s "):
+            bad_actions.append(item)
+
+        key = _action_key(item)
+        if key in seen_actions:
+            duplicate_actions.append(item)
+        seen_actions.add(key)
+
+    for step in next_steps:
+        step_lower = _norm(step).lower()
+        if "keep the launch scope focused on upload" in step_lower or step_lower.startswith("s "):
+            bad_next_steps.append(step)
+
+    for point in key_points:
+        point_lower = _norm(point).lower()
+        if "control.reach" in point_lower or "s keep" in point_lower:
+            bad_key_points.append(point)
+
+    score = 100
+
+    if len(decisions) < 3:
+        score -= 15
+    if len(actions) < 3:
+        score -= 20
+    if len(next_steps) < 3:
+        score -= 15
+    if not has_weekly_priority_action:
+        score -= 15
+    if bad_decisions:
+        score -= 15
+    if bad_actions:
+        score -= 20
+    if bad_next_steps:
+        score -= 15
+    if bad_key_points:
+        score -= 10
+    if duplicate_actions:
+        score -= 10
+
+    score = max(score, 0)
+
+    print("CLIENT-FACING PILOT RC1 QUALITY GATE")
+    print("-----------------------------------")
+    print(f"input: {path}")
+    print(f"decision_count: {len(decisions)}")
+    print(f"action_count: {len(actions)}")
+    print(f"next_steps_count: {len(next_steps)}")
+    print(f"has_weekly_priority_action: {has_weekly_priority_action}")
+    print(f"client_facing_score: {score}")
+    print(f"bad_decisions: {bad_decisions}")
+    print(f"bad_actions: {bad_actions}")
+    print(f"bad_next_steps: {bad_next_steps}")
+    print(f"bad_key_points: {bad_key_points}")
+    print(f"duplicate_actions: {duplicate_actions}")
+    print()
+
+    passed = (
+        score >= 95
+        and len(decisions) >= 3
+        and len(actions) >= 3
+        and len(next_steps) >= 3
+        and has_weekly_priority_action
+        and not bad_decisions
+        and not bad_actions
+        and not bad_next_steps
+        and not bad_key_points
+        and not duplicate_actions
+    )
+
+    if passed:
+        print("CLIENT_FACING_REHEARSAL_PASS")
+        return 0
+
+    print("CLIENT_FACING_REHEARSAL_REVIEW_NEEDED")
+    return 1
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: python scripts/quality_gates/pilot_rc1_client_facing_gate.py <notes_ai.json>")
+        return 2
+
+    path = Path(sys.argv[1])
+    if not path.exists():
+        print(f"File not found: {path}")
+        return 2
+
+    return evaluate(path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a reusable strict quality gate for the Pilot RC1 client-facing rehearsal output.

This gate evaluates whether generated meeting notes are ready for a client-facing demo by checking decision recall, action-item recall, next-step quality, duplicate actions, malformed outputs, and overall client-facing score.

## What Changed

- Added `scripts/quality_gates/pilot_rc1_client_facing_gate.py`
- Added baseline evidence documentation at:
  - `docs/pilot/pilot_rc1_client_facing_quality_gate_baseline.md`

## Baseline Result

The current client-facing rehearsal does not yet pass the strict gate.

Observed baseline:

```text
decision_count: 5
action_count: 2
next_steps_count: 1
has_weekly_priority_action: False
client_facing_score: 50
bad_decisions: []
bad_actions: []
bad_next_steps: []
bad_key_points: []
duplicate_actions: []

CLIENT_FACING_REHEARSAL_REVIEW_NEEDED
QUALITY_GATE_EXIT_CODE=1