### PR TITLE
Lock Pilot RC1 launch-readiness demo package

### DIFF
--- a/docs/pilot/pilot_rc1_launch_readiness_demo_lock.md
+++ b/docs/pilot/pilot_rc1_launch_readiness_demo_lock.md
@@ -1,0 +1,112 @@
+# Pilot RC1 Launch-Readiness Demo Lock
+
+## Purpose
+
+This document locks the Pilot RC1 launch-readiness verification and public-demo package for the Meeting Notes Assistant.
+
+The goal is to confirm that the current release candidate is ready for controlled public demo usage without introducing risky new extraction changes.
+
+## Current baseline
+
+Latest merged main:
+
+9d682c78 Improve client-facing action and JSON output cleanup
+
+Confirmed baseline:
+
+- Repository started clean
+- Main was up to date with origin/main
+- Pilot RC1 client-facing action and next-step recall improved
+- /notes/ai JSON boundary cleanup added
+- Final sanitizer strengthened
+- Client-facing gate strengthened
+- Regression coverage added
+- CI smoke migration ordering fixed
+- Evidence archived locally outside repo
+
+Previous evidence archive:
+
+../mna_pilot_rc1_client_facing_evidence_20260428_022623.tar.gz
+
+## Launch-safe product claim
+
+Best for short, structured business meetings.
+
+## Demo positioning
+
+Meeting Notes Assistant turns short business meeting recordings into:
+
+- Structured summaries
+- Key points
+- Decisions
+- Action items
+- Next steps
+- Markdown notes
+- JSON output for downstream use
+
+## Public-demo lock principle
+
+This branch should focus on verification, packaging, evidence, and launch-safe documentation.
+
+Allowed changes:
+
+- Verification documentation
+- Launch-readiness checklist
+- Demo package documentation
+- Evidence capture
+- Small launch-blocker fixes only if required
+
+Avoid:
+
+- Broad extraction rewrites
+- New summarization architecture changes
+- UI scope expansion
+- Unsupported product claims
+- Over-optimizing for one meeting at the cost of safety
+
+## Launch-readiness acceptance criteria
+
+Pilot RC1 is considered ready for controlled public demo only if:
+
+1. Repository starts clean from latest main
+2. Regression tests pass
+3. Pilot RC1 quality gate passes
+4. 10-minute client-facing demo output is clean and publishable
+5. Markdown export is readable and client-safe
+6. /notes/ai JSON has no boundary artifacts
+7. Action items are specific, useful, and not noisy
+8. Next steps are clear and client-safe
+9. Decisions are preserved where present
+10. Non-meeting safety behavior remains intact
+11. Evidence is archived outside the repository
+12. Known limitations are documented
+
+## Known limitations
+
+Current Pilot RC1 should not be over-claimed as a universal meeting intelligence platform yet.
+
+Avoid claims such as:
+
+- Works perfectly for all meetings
+- Fully replaces human review
+- Handles every long meeting reliably
+- Enterprise-ready without further security/compliance hardening
+- Accurate for every noisy, informal, or multi-speaker recording
+
+Use conservative wording:
+
+Designed for short, structured business meetings, with human review recommended before sharing externally.
+
+## Public-demo recommendation
+
+- Use validated short structured business meeting audio
+- Keep the demo focused on summary, decisions, action items, and next steps
+- Show both markdown and JSON only if the audience is technical
+- Do not demo unsupported long-form or non-meeting audio as the primary flow
+- Keep backup demo artifacts ready in case live processing fails
+
+## Launch decision
+
+Status: Pending launch-readiness verification
+
+Final launch-readiness decision should be recorded after regression checks, Pilot RC1 quality gate, demo output review, markdown review, JSON review, and evidence archive creation.

--- a/docs/pilot/pilot_rc1_launch_readiness_demo_lock.md
+++ b/docs/pilot/pilot_rc1_launch_readiness_demo_lock.md
@@ -110,3 +110,35 @@ Designed for short, structured business meetings, with human review recommended 
 Status: Pending launch-readiness verification
 
 Final launch-readiness decision should be recorded after regression checks, Pilot RC1 quality gate, demo output review, markdown review, JSON review, and evidence archive creation.
+
+## Launch-readiness verification result
+
+Status: PASS
+
+Pilot RC1 passed the launch-readiness quality gate for controlled public demo usage.
+
+Verification result:
+
+- Quality gate score: 100/100
+- Threshold: 85/100
+- Final status: PASS
+- Meeting ID: 280
+- Job ID: 10262856-7ec3-4b60-8046-f0e0c9a9ecd9
+- Audio file: backend/storage/uploads/meeting_115.m4a
+- Final job status: succeeded
+
+Runtime note:
+
+An earlier quality-gate attempt stayed queued because the local worker was not consuming jobs. After the worker/runtime issue was resolved, the job moved from queued to running to succeeded.
+
+Known verification note:
+
+Full-backend mypy still has existing typing debt across the repository. This branch does not change backend product code, so that typing cleanup should be handled separately.
+
+Final launch decision:
+
+Pilot RC1 is ready for controlled public-demo use with the conservative claim:
+
+Best for short, structured business meetings.
+
+Human review is still recommended before externally sharing generated notes.


### PR DESCRIPTION
## Summary

This PR locks the Pilot RC1 launch-readiness demo package for controlled public-demo usage.

## What changed

- Added Pilot RC1 launch-readiness demo lock documentation
- Recorded the final launch-readiness verification result
- Confirmed the public-demo-safe product claim
- Documented known limitations and verification notes
- Preserved this branch as documentation-focused, with no backend product-code changes

## Verification

Pilot RC1 quality gate passed:

- Score: 100/100
- Threshold: 85/100
- Status: PASS
- Meeting ID: 280
- Job ID: 10262856-7ec3-4b60-8046-f0e0c9a9ecd9
- Audio file: backend/storage/uploads/meeting_115.m4a
- Final job status: succeeded

Additional checks completed:

- compileall backend/app passed
- ruff check backend passed
- focused regression tests passed: 2 passed
- generated test outputs restored before commit
- final working tree clean

## Runtime note

An earlier quality-gate attempt stayed queued because the local worker was not consuming jobs. After the worker/runtime issue was resolved, the job moved from queued to running to succeeded.

## Known verification note

Full-backend mypy still has existing typing debt across the repository. This branch does not change backend product code, so that cleanup should be handled separately.

## Launch-safe claim

Best for short, structured business meetings.

Human review is still recommended before externally sharing generated notes.

## Evidence archive

Local evidence archive saved outside the repository:

../mna_pilot_rc1_launch_readiness_demo_lock_20260428_151428.tar.gz