### PR TITLE
Add Pilot RC1 demo artifact and first-user pack

### DIFF
--- a/docs/pilot/pilot_rc1_demo_artifact_first_user_pack.md
+++ b/docs/pilot/pilot_rc1_demo_artifact_first_user_pack.md
@@ -1,0 +1,151 @@
+# Pilot RC1 Demo Artifact Bundle and First-User Pilot Intake Pack
+
+## Purpose
+
+This document packages the practical assets needed to run controlled Pilot RC1 demos and first-user pilots for the Meeting Notes Assistant.
+
+The goal is to make demos repeatable, professional, and low-risk while collecting useful pilot feedback.
+
+## Current locked baseline
+
+Latest main baseline:
+
+7e0b398d Add Pilot RC1 public demo execution package
+
+Pilot RC1 status:
+
+- Launch-readiness: GREEN
+- Quality gate: 100/100 PASS
+- Public-demo execution package: added
+- Launch-safe claim: Best for short, structured business meetings.
+
+## Demo artifact checklist
+
+Before any live demo, prepare:
+
+- Validated short structured demo audio
+- Generated notes.md backup output
+- Generated notes_ai.json backup output
+- Quality gate report screenshot or copied text
+- Product one-liner
+- Launch-safe claim
+- Known limitations wording
+- Follow-up email template
+- First-user intake questions
+- Pilot feedback questions
+
+## Backup artifact index
+
+Recommended backup artifacts:
+
+- test_outputs/pilot_rc1_quality_gate/notes.md
+- test_outputs/pilot_rc1_quality_gate/notes_ai.json
+- test_outputs/pilot_rc1_quality_gate/quality_gate_report.md
+- docs/pilot/pilot_rc1_launch_readiness_demo_lock.md
+- docs/pilot/pilot_rc1_public_demo_execution_package.md
+
+Backup message if live processing is slow:
+
+The live processing environment is taking longer than expected, so I will show a saved output from the same validated Pilot RC1 demo flow.
+
+## Product one-liner
+
+Meeting Notes Assistant helps turn short business meeting recordings into structured summaries, decisions, action items, and next steps.
+
+## Launch-safe claim
+
+Best for short, structured business meetings.
+
+## Public limitations wording
+
+This Pilot RC1 version is designed for short, structured business meetings. Human review is recommended before sharing generated notes externally.
+
+Avoid saying:
+
+- Works perfectly for every meeting
+- Replaces human review
+- Enterprise-ready without additional compliance review
+- Handles all long, noisy, informal, or multi-speaker recordings reliably
+
+## First-user intake questions
+
+Ask these before processing a pilot meeting:
+
+1. What type of meeting is this?
+2. How long is the recording?
+3. Is the meeting structured with clear topics or agenda items?
+4. What output matters most: summary, decisions, action items, or next steps?
+5. Will the notes be used internally or shared with a client?
+6. Are there any sensitive names, client details, or confidential terms to avoid sharing publicly?
+7. What would make the generated notes useful enough for your workflow?
+
+## Pilot feedback questions
+
+Ask these after the pilot output is reviewed:
+
+1. Was the summary accurate enough to understand the meeting?
+2. Were the key decisions captured correctly?
+3. Were the action items specific and useful?
+4. Were any important next steps missed?
+5. Was anything noisy, incorrect, or confusing?
+6. Would you use this for another short business meeting?
+7. What one improvement would make this more valuable?
+
+## Pilot success metrics
+
+Track these for early pilots:
+
+- User understood product value within two minutes
+- Summary was judged useful
+- Decisions were judged useful
+- Action items were judged useful
+- User identified at least one practical workflow use case
+- User agreed to try another meeting or provide feedback
+- No unsupported product claims were made
+
+## Launch-safe outreach message
+
+Hi [Name],
+
+I am piloting Meeting Notes Assistant, a tool that helps turn short business meeting recordings into structured summaries, decisions, action items, and next steps.
+
+The current version is best for short, structured business meetings, and I am collecting feedback from a small number of early users.
+
+Would you be open to trying it with one short meeting or reviewing a quick demo output?
+
+Best,
+Lalita
+
+## Follow-up email after demo
+
+Subject: Thank you for reviewing Meeting Notes Assistant
+
+Hi [Name],
+
+Thank you for taking time to review the Meeting Notes Assistant demo.
+
+As shared, the current Pilot RC1 version is best for short, structured business meetings. It is designed to help capture summaries, decisions, action items, and next steps, with human review recommended before external sharing.
+
+I would appreciate your feedback on three points:
+
+1. Was the output useful?
+2. Were the action items and decisions clear?
+3. What would make this more valuable for your workflow?
+
+Best,
+Lalita
+
+## Operating rules for first pilots
+
+- Start with one short structured meeting
+- Review generated notes before sharing externally
+- Capture feedback immediately after review
+- Do not promise enterprise SLA, compliance certification, or universal accuracy
+- Record issues as product feedback, not as ad hoc live fixes
+- Keep the pilot focused on business value and workflow fit
+
+## Final recommendation
+
+Proceed with first-user pilots using the locked Pilot RC1 baseline and conservative public positioning.
+
+Prioritize feedback quality over volume. The goal is to validate workflow usefulness before broad launch claims are expanded.


### PR DESCRIPTION
## Summary

This PR adds the Pilot RC1 demo artifact bundle and first-user pilot intake pack.

## What changed

- Added demo artifact checklist
- Added backup artifact index
- Added product one-liner
- Added launch-safe claim and public limitations wording
- Added first-user intake questions
- Added pilot feedback questions
- Added pilot success metrics
- Added launch-safe outreach message
- Added follow-up email after demo
- Added operating rules for first pilots

## Current locked baseline

- Latest main baseline: 7e0b398d Add Pilot RC1 public demo execution package
- Launch-readiness: GREEN
- Quality gate: 100/100 PASS
- Public-demo execution package: added
- Launch-safe claim: Best for short, structured business meetings.

## Risk control

This PR is documentation/demo-ops focused only.

It does not introduce backend extraction changes, summarization changes, UI changes, or new product claims.

## Pilot recommendation

Proceed with first-user pilots using the locked Pilot RC1 baseline and conservative public positioning.

Prioritize feedback quality over volume. The goal is to validate workflow usefulness before broad launch claims are expanded.