### PR TITLE
Add Pilot RC1 first-user outreach feedback pack

### DIFF
--- a/docs/pilot/pilot_rc1_first_user_outreach_feedback_pack.md
+++ b/docs/pilot/pilot_rc1_first_user_outreach_feedback_pack.md
@@ -1,0 +1,173 @@
+# Pilot RC1 First-User Outreach and Feedback Execution Pack
+
+## Purpose
+
+This document defines the first-user outreach and feedback execution pack for Pilot RC1 of the Meeting Notes Assistant.
+
+The goal is to move from launch readiness into controlled first-user pilot execution while keeping feedback structured, measurable, and useful for product improvement.
+
+## Current locked baseline
+
+Latest main baseline:
+
+482ac121 Add Pilot RC1 launch-day dry run and first-pilot tracker
+
+Pilot RC1 status:
+
+- Launch-readiness lock: complete
+- Public-demo execution package: complete
+- Demo artifact and first-user pack: complete
+- Launch-day dry run: GO / PASS
+- Quality gate: 100/100 PASS
+- Controlled first-user pilot status: READY
+- Launch-safe claim: Best for short, structured business meetings.
+
+## Outreach objective
+
+The first outreach cycle should validate whether early users understand the product value and are willing to try the tool on one short structured business meeting.
+
+Primary target segments:
+
+- Consultants
+- Agencies
+- Founders
+- Startup operators
+- Small business teams with recurring client or internal meetings
+
+## Target pilot-user list template
+
+| Priority | Name | Segment | Relationship | Meeting use case | Outreach status | Next step |
+| --- | --- | --- | --- | --- | --- | --- |
+| P1 | TBD | Founder or consultant | Warm contact | Short structured business meeting | Not started | Identify first target |
+| P2 | TBD | Agency or small team | Warm contact | Client sync or weekly update | Not started | Identify second target |
+| P3 | TBD | Startup operator | Warm or referral | Internal planning meeting | Not started | Identify third target |
+
+## Demo invitation message
+
+Hi [Name],
+
+I am piloting Meeting Notes Assistant, a tool that helps turn short business meeting recordings into structured summaries, decisions, action items, and next steps.
+
+The current version is best for short, structured business meetings, and I am collecting feedback from a small number of early users.
+
+Would you be open to reviewing a quick demo or trying it with one short meeting?
+
+Best,
+Lalita
+
+## Short LinkedIn-style outreach message
+
+Hi [Name], I am piloting a Meeting Notes Assistant that turns short structured business meetings into summaries, decisions, action items, and next steps. I am looking for a few early users to review a quick demo or test one short meeting. Would you be open to giving feedback?
+
+## Post-demo follow-up message
+
+Subject: Thank you for reviewing Meeting Notes Assistant
+
+Hi [Name],
+
+Thank you for reviewing the Meeting Notes Assistant demo.
+
+As shared, the current Pilot RC1 version is best for short, structured business meetings. It is designed to help capture summaries, decisions, action items, and next steps, with human review recommended before external sharing.
+
+I would appreciate your feedback on three points:
+
+1. Was the output useful for your workflow?
+2. Were the decisions and action items clear?
+3. What would make this more valuable for you?
+
+Best,
+Lalita
+
+## Pilot intake questions
+
+Ask before processing a first-user pilot meeting:
+
+1. What type of meeting is this?
+2. How long is the recording?
+3. Is the meeting structured with clear topics or agenda items?
+4. What output matters most: summary, decisions, action items, or next steps?
+5. Will the notes be used internally or shared externally?
+6. Are there sensitive names, client details, or confidential terms to avoid sharing publicly?
+7. What would make the generated notes useful enough for your workflow?
+
+## Feedback scoring rubric
+
+| Category | Score 1 | Score 3 | Score 5 |
+| --- | --- | --- | --- |
+| Summary usefulness | Not useful | Somewhat useful | Clearly useful |
+| Decision capture | Missed or wrong | Partially correct | Clear and correct |
+| Action item quality | Vague or missing | Some useful actions | Specific and useful |
+| Next-step clarity | Unclear | Partially clear | Clear and practical |
+| Client-facing readability | Not shareable | Needs editing | Mostly ready after review |
+| Workflow value | No clear value | Possible value | Strong practical value |
+
+Recommended interpretation:
+
+- Average score 4.0 or higher: strong pilot signal
+- Average score 3.0 to 3.9: useful but needs improvement
+- Average score below 3.0: investigate before broader outreach
+
+## First-user outcome tracker
+
+| Pilot user | Segment | Meeting type | Demo date | Summary score | Decision score | Action score | Outcome | Next step |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| TBD | TBD | TBD | TBD | Pending | Pending | Pending | Pending | Identify first pilot user |
+
+## Weekly pilot review process
+
+Review first-user pilot progress weekly during the initial pilot period.
+
+Weekly review checklist:
+
+- Number of outreach messages sent
+- Number of responses received
+- Number of demos completed
+- Number of pilot meetings processed
+- Average feedback score
+- Most common missing item
+- Most common user confusion
+- Highest-value user segment
+- Product changes that should be considered later
+
+## Structured feedback format
+
+Record feedback in this format:
+
+| Date | User segment | Meeting type | Positive signal | Issue found | Severity | Suggested follow-up |
+| --- | --- | --- | --- | --- | --- | --- |
+| TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+
+Severity levels:
+
+- Low: wording or formatting issue
+- Medium: useful output but some missed information
+- High: user would not trust the result without major edits
+- Blocker: output is not safe to share or demo
+
+## Launch-safe operating rules
+
+- Use the conservative claim: Best for short, structured business meetings.
+- Recommend human review before external sharing.
+- Do not claim universal meeting accuracy.
+- Do not claim enterprise readiness without further security and compliance review.
+- Do not process highly sensitive or confidential recordings as public examples.
+- Capture feedback as structured product evidence.
+- Do not make live product-code changes during outreach or demo sessions.
+
+## First-user pilot success criteria
+
+The first-user pilot cycle is successful if:
+
+- At least three target users are contacted
+- At least one demo is completed
+- At least one user provides structured feedback
+- The user understands the best-fit use case
+- The output is considered useful enough for internal review
+- No unsupported product claims are made
+- Any issues are recorded for future product workstreams
+
+## Final recommendation
+
+Proceed with controlled first-user outreach using the locked Pilot RC1 baseline.
+
+Prioritize warm contacts, short structured meetings, and high-quality feedback over large-volume outreach.


### PR DESCRIPTION
## Summary

This PR adds the Pilot RC1 first-user outreach and feedback execution pack.

## What changed

- Added first-user outreach objective
- Added target pilot-user list template
- Added demo invitation message
- Added short LinkedIn-style outreach message
- Added post-demo follow-up message
- Added pilot intake questions
- Added feedback scoring rubric
- Added first-user outcome tracker
- Added weekly pilot review process
- Added structured feedback format
- Added launch-safe operating rules
- Added first-user pilot success criteria

## Current locked baseline

- Latest main baseline: 482ac121 Add Pilot RC1 launch-day dry run and first-pilot tracker
- Launch-readiness lock: complete
- Public-demo execution package: complete
- Demo artifact and first-user pack: complete
- Launch-day dry run: GO / PASS
- Quality gate: 100/100 PASS
- Controlled first-user pilot status: READY

## Launch-safe claim

Best for short, structured business meetings.

Human review remains recommended before sharing generated notes externally.

## Risk control

This PR is documentation/demo-ops focused only.

It does not introduce backend extraction changes, summarization changes, UI changes, or expanded product claims.

## Pilot recommendation

Proceed with controlled first-user outreach using the locked Pilot RC1 baseline.

Prioritize warm contacts, short structured meetings, and high-quality feedback over large-volume outreach.