### PR TITLE
Add Pilot RC1 first-user pilot execution log

### DIFF
--- a/docs/pilot/pilot_rc1_first_user_pilot_execution_log.md
+++ b/docs/pilot/pilot_rc1_first_user_pilot_execution_log.md
@@ -1,0 +1,260 @@
+# Pilot RC1 First-User Pilot Execution Log
+
+## Purpose
+
+This document tracks actual first-user pilot execution for Pilot RC1 of the Meeting Notes Assistant.
+
+The goal is to move from outreach packaging into real pilot tracking while keeping outreach, responses, demos, feedback, issues, and product-learning evidence structured.
+
+## Current locked baseline
+
+Latest main baseline:
+
+547e610e Add Pilot RC1 first-user outreach feedback pack
+
+Pilot RC1 status:
+
+- Launch-readiness lock: complete
+- Public-demo execution package: complete
+- Demo artifact and first-user pack: complete
+- Launch-day dry run: GO / PASS
+- Quality gate: 100/100 PASS
+- First-user outreach feedback pack: complete
+- Controlled first-user pilot status: READY
+- Launch-safe claim: Best for short, structured business meetings.
+
+## Execution objective
+
+The first-user pilot cycle should validate whether early users understand the product value and find the generated notes useful for short, structured business meetings.
+
+Primary goals:
+
+- Record real outreach attempts
+- Track first user responses
+- Track demo scheduling
+- Track feedback scores
+- Capture pilot outcome decisions
+- Identify product improvement themes
+- Separate runtime issues from product-quality issues
+- Prepare evidence for launch-progress review
+
+## Outreach execution log
+
+| Date | Contact | Segment | Channel | Message used | Status | Next step |
+| --- | --- | --- | --- | --- | --- | --- |
+| TBD | TBD | Founder / consultant / agency / startup operator | TBD | Demo invitation / LinkedIn-style message | Not started | Identify first warm contact |
+| TBD | TBD | TBD | TBD | TBD | Not started | Identify second contact |
+| TBD | TBD | TBD | TBD | TBD | Not started | Identify third contact |
+
+## Response tracker
+
+| Contact | Response | Interest level | Demo requested | Meeting file available | Follow-up needed |
+| --- | --- | --- | --- | --- | --- |
+| TBD | Pending | Pending | No | No | Yes |
+
+Interest levels:
+
+- High: wants demo or wants to test with meeting
+- Medium: interested but not scheduled
+- Low: polite response but no clear pilot interest
+- No response: no reply yet
+- Not fit: meeting type or use case is not aligned
+
+## Demo scheduling tracker
+
+| Contact | Demo date | Demo status | Demo format | Notes |
+| --- | --- | --- | --- | --- |
+| TBD | TBD | Not scheduled | Live demo / recorded walkthrough / artifact review | Pending |
+
+Demo status options:
+
+- Not scheduled
+- Scheduled
+- Completed
+- Rescheduled
+- Cancelled
+
+## Pilot meeting execution log
+
+| Pilot user | Segment | Meeting type | Recording length | Processing status | Output reviewed | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| TBD | TBD | Short structured business meeting | TBD | Pending | No | Waiting for first pilot meeting |
+
+Processing status options:
+
+- Pending
+- Processing
+- Completed
+- Failed runtime
+- Not processed due to fit or sensitivity concern
+
+## Feedback score tracker
+
+Use score 1 to 5 for each category.
+
+| Pilot user | Summary usefulness | Decision capture | Action item quality | Next-step clarity | Readability | Workflow value | Average score |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| TBD | Pending | Pending | Pending | Pending | Pending | Pending | Pending |
+
+Score interpretation:
+
+- 5: Strong positive signal
+- 4: Useful with minor edits
+- 3: Some value but needs improvement
+- 2: Weak usefulness
+- 1: Not useful or not trusted
+
+Pilot signal interpretation:
+
+- Average score 4.0 or higher: strong pilot signal
+- Average score 3.0 to 3.9: useful but needs improvement
+- Average score below 3.0: investigate before broader outreach
+
+## Qualitative feedback log
+
+| Date | Pilot user | Positive signal | Issue found | User quote or paraphrase | Severity | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- |
+| TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+
+Severity levels:
+
+- Low: wording, formatting, or presentation issue
+- Medium: useful output but some missed information
+- High: user would not trust the output without major edits
+- Blocker: output is unsafe, misleading, or not demo-ready
+
+## Product improvement themes
+
+| Theme | Evidence source | Frequency | Impact | Recommended follow-up |
+| --- | --- | --- | --- | --- |
+| TBD | TBD | TBD | TBD | TBD |
+
+Theme examples:
+
+- Summary clarity
+- Decision recall
+- Action item specificity
+- Next-step usefulness
+- Markdown readability
+- JSON cleanliness
+- Upload or runtime reliability
+- User onboarding confusion
+- Pricing or packaging feedback
+
+## Runtime issue log
+
+Use this section only for environment, service, queue, worker, Docker, storage, or processing reliability issues.
+
+| Date | Issue | Component | Severity | Resolution | Follow-up branch needed |
+| --- | --- | --- | --- | --- | --- |
+| TBD | No runtime issue recorded yet | TBD | TBD | TBD | TBD |
+
+Runtime components:
+
+- Backend
+- Worker
+- Redis
+- Database
+- MinIO / storage
+- Docker
+- Quality gate script
+- Local machine environment
+
+## Product-quality issue log
+
+Use this section only for output quality concerns.
+
+| Date | Issue | Output area | Severity | Example | Follow-up branch needed |
+| --- | --- | --- | --- | --- | --- |
+| TBD | No product-quality issue recorded yet | TBD | TBD | TBD | TBD |
+
+Output areas:
+
+- Summary
+- Purpose
+- Outcome
+- Key points
+- Decisions
+- Action items
+- Next steps
+- Markdown
+- JSON
+
+## Pilot outcome decision log
+
+| Pilot user | Outcome | Reason | Next action |
+| --- | --- | --- | --- |
+| TBD | Pending | Waiting for first pilot | Identify first user |
+
+Outcome options:
+
+- Continue pilot
+- Needs follow-up demo
+- Needs product fix
+- Not a fit
+- Strong validation signal
+- Conversion opportunity later
+
+## Weekly launch-progress review
+
+Review weekly during first-user pilot period.
+
+Weekly metrics:
+
+| Week | Outreach sent | Responses | Demos completed | Meetings processed | Avg score | Key learning | Decision |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Week 1 | 0 | 0 | 0 | 0 | Pending | Pending | Start outreach |
+
+Weekly review questions:
+
+1. Which segment showed the strongest interest?
+2. Did users understand the product value quickly?
+3. Which output section created the most value?
+4. Which output section caused the most concern?
+5. Were any issues runtime-related rather than product-quality-related?
+6. Is the launch-safe claim still accurate?
+7. Should outreach continue, pause, or narrow to a better-fit segment?
+
+## Evidence checklist
+
+For each real pilot, preserve evidence outside the repository when appropriate.
+
+Recommended evidence:
+
+- Outreach message sent
+- User response summary
+- Demo date
+- Intake notes
+- Processing result
+- Feedback scores
+- Key qualitative feedback
+- Issue classification
+- Follow-up decision
+
+Do not commit private user recordings, private transcripts, sensitive client names, or confidential pilot details into the repository.
+
+## Launch-safe operating rules
+
+- Use the conservative claim: Best for short, structured business meetings.
+- Recommend human review before external sharing.
+- Do not claim universal meeting accuracy.
+- Do not claim enterprise readiness without further security and compliance review.
+- Do not process highly sensitive or confidential recordings as public examples.
+- Do not commit private pilot data into the repository.
+- Capture feedback as structured product evidence.
+- Separate runtime problems from product-quality problems.
+- Do not make live product-code changes during outreach or demo sessions.
+
+## Initial execution status
+
+Status: Ready for first-user outreach
+
+Next action:
+
+Identify and contact the first three warm pilot candidates.
+
+## Final recommendation
+
+Proceed with controlled first-user pilot execution using the locked Pilot RC1 baseline.
+
+Prioritize quality of learning over volume of outreach.


### PR DESCRIPTION
## Summary

This PR adds the Pilot RC1 first-user pilot execution log.

## What changed

- Added outreach execution log
- Added response tracker
- Added demo scheduling tracker
- Added pilot meeting execution log
- Added feedback score tracker
- Added qualitative feedback log
- Added product improvement themes tracker
- Added runtime issue log
- Added product-quality issue log
- Added pilot outcome decision log
- Added weekly launch-progress review
- Added evidence checklist
- Added launch-safe operating rules

## Current locked baseline

- Latest main baseline: 547e610e Add Pilot RC1 first-user outreach feedback pack
- Launch-readiness lock: complete
- Public-demo execution package: complete
- Demo artifact and first-user pack: complete
- Launch-day dry run: GO / PASS
- Quality gate: 100/100 PASS
- First-user outreach feedback pack: complete
- Controlled first-user pilot status: READY

## Launch-safe claim

Best for short, structured business meetings.

Human review remains recommended before sharing generated notes externally.

## Risk control

This PR is documentation/demo-ops focused only.

It does not introduce backend extraction changes, summarization changes, UI changes, or expanded product claims.

It also reminds that private user recordings, private transcripts, sensitive client names, and confidential pilot details should not be committed into the repository.

## Pilot recommendation

Proceed with controlled first-user pilot execution using the locked Pilot RC1 baseline.

Prioritize quality of learning over volume of outreach.