### PR TITLE
Harden Pilot RC1 golden gate polling timeout

### DIFF
--- a/scripts/pilot_rc1_golden_consistency_gate.sh
+++ b/scripts/pilot_rc1_golden_consistency_gate.sh
@@ -2,11 +2,15 @@
 set -euo pipefail
 
 BASE_URL="${BASE_URL:-http://127.0.0.1:8000}"
+MAX_POLL_ATTEMPTS="${MAX_POLL_ATTEMPTS:-240}"
+POLL_SLEEP_SECONDS="${POLL_SLEEP_SECONDS:-2}"
 OUT_DIR="test_outputs/pilot_rc1_golden_consistency_gate_$(date +%Y%m%d_%H%M%S)"
 mkdir -p "$OUT_DIR"
 
 echo "Pilot RC1 Golden Consistency Gate"
 echo "Base URL: $BASE_URL"
+echo "Max poll attempts: $MAX_POLL_ATTEMPTS"
+echo "Poll sleep seconds: $POLL_SLEEP_SECONDS"
 echo "Output directory: $OUT_DIR"
 echo
 
@@ -72,7 +76,7 @@ for SAMPLE in "${SAMPLE_FILES[@]}"; do
   echo "Poll job"
   JOB_STATUS="unknown"
 
-  for i in $(seq 1 120); do
+  for i in $(seq 1 "$MAX_POLL_ATTEMPTS"); do
     JOB_RESP="$(curl -fsS "$BASE_URL/v1/jobs/$JOB_ID")"
     echo "$JOB_RESP" > "$SAMPLE_OUT/job_latest.json"
 
@@ -83,7 +87,7 @@ for SAMPLE in "${SAMPLE_FILES[@]}"; do
       break
     fi
 
-    sleep 2
+    sleep "$POLL_SLEEP_SECONDS"
   done
 
   if [ "$JOB_STATUS" != "succeeded" ]; then


### PR DESCRIPTION
Harden the Pilot RC1 golden consistency gate by making job polling settings configurable and increasing the default timeout.

This updates scripts/pilot_rc1_golden_consistency_gate.sh to add:

- MAX_POLL_ATTEMPTS with a default of 240
- POLL_SLEEP_SECONDS with a default of 2
- printed runtime settings for easier debugging

Why:

The successful Pilot RC1 golden gate run showed that Meeting 86 completed correctly but very close to the previous 120-attempt timeout. Since Meeting 86 is the key non-meeting safety guardrail, the gate should not fail randomly on slower local machines or heavier processing runs.

This change increases the default polling window from approximately 4 minutes to approximately 8 minutes while still allowing overrides through environment variables.

Example override:

MAX_POLL_ATTEMPTS=300 POLL_SLEEP_SECONDS=2 ./scripts/pilot_rc1_golden_consistency_gate.sh

Validation:

- Bash syntax validation passed with bash -n
- Pre-commit checks passed:
  - ruff skipped, no Python files changed
  - ruff format skipped, no Python files changed
  - mypy skipped, no Python files changed
  - fix end of files passed
  - trim trailing whitespace passed