### PR TITLE
Add Pilot RC1 launch candidate summary

### DIFF
--- a/docs/pilot/pilot_rc1_launch_candidate_summary.md
+++ b/docs/pilot/pilot_rc1_launch_candidate_summary.md
@@ -1,0 +1,155 @@
+# Pilot RC1 Launch Candidate Summary
+
+## Current status
+
+Pilot RC1 is ready for controlled pilot demos.
+
+Current readiness interpretation:
+
+**92-95 / 100 controlled pilot readiness**
+
+Latest hardened golden consistency gate result:
+
+**95.5 / 100**
+
+Passing samples:
+
+**4 / 4**
+
+---
+
+## Supported external positioning
+
+The strongest supported external claim is:
+
+**Best for short, structured business meetings.**
+
+Recommended demo positioning:
+
+The Meeting Notes Assistant turns short meeting recordings into structured summaries, decisions, action items, and clean markdown notes.
+
+---
+
+## What Pilot RC1 can do well
+
+Pilot RC1 currently supports:
+
+- upload meeting audio
+- process the meeting through the backend worker pipeline
+- generate structured AI notes
+- extract summaries, decisions, and action items
+- produce clean client-facing markdown
+- preserve non-meeting safety behavior
+- avoid fake decisions and fake actions in non-meeting audio
+- run repeatable quality checks through the golden consistency gate
+
+---
+
+## Golden gate evidence
+
+Latest hardened validation run:
+
+| Sample | Status | Score | Actions | Decisions | Markdown | Safety Signal |
+|---|---:|---:|---:|---:|---:|---:|
+| client_weekly_sync_10min_m4a | PASS | 97 | 6 | 4 | True | False |
+| meeting_30min_script_wav | PASS | 100 | 6 | 5 | True | False |
+| meeting_81_m4a | PASS | 97 | 6 | 4 | True | False |
+| meeting_86_mp3 | PASS | 88 | 0 | 0 | True | True |
+
+Overall average score:
+
+**95.5 / 100**
+
+Passing samples:
+
+**4 / 4**
+
+---
+
+## Trust and safety validation
+
+Meeting 86 remains the key safety benchmark.
+
+It confirms that non-meeting or unclear audio is not converted into fake business decisions or fake action items.
+
+Latest result:
+
+- decisions: 0
+- action items: 0
+- safety signal: true
+
+This is important for pilot trust.
+
+---
+
+## Operational hardening completed
+
+The golden consistency gate now includes:
+
+- configurable polling timeout
+- longer default polling window for slower samples
+- worker preflight check
+- fail-fast behavior if the worker is not running
+- clear remediation instructions for worker failures
+
+This reduces false failures during demo readiness checks.
+
+---
+
+## Known limits
+
+Pilot RC1 should not yet be positioned as:
+
+- perfect for every meeting type
+- fully public general availability
+- production enterprise-grade compliance system
+- guaranteed accurate without human review
+- optimized for very noisy, highly unstructured, or very long recordings
+
+Human review is still recommended before sharing notes externally.
+
+---
+
+## Recommended demo flow
+
+1. Start backend, worker, database, Redis, and storage.
+2. Confirm `/healthz` is healthy.
+3. Confirm worker preflight passes.
+4. Upload a short structured business meeting.
+5. Show generated structured notes.
+6. Show decisions and action items.
+7. Show markdown export.
+8. Use the launch-safe message:
+
+**Best for short, structured business meetings.**
+
+---
+
+## Pilot success criteria
+
+A controlled pilot is successful if:
+
+- users understand the output quickly
+- summaries are useful without heavy explanation
+- decisions and action items are mostly correct
+- users trust the markdown export
+- users ask to use it on their own meetings
+- no fake action items are produced on unclear/non-meeting audio
+- feedback identifies polish needs rather than core product confusion
+
+---
+
+## Launch decision
+
+Pilot RC1 is suitable for controlled pilot demos.
+
+Recommended next action:
+
+Proceed with 3-5 trusted first-user pilots.
+
+Do not broaden to public launch until pilot feedback confirms:
+
+- users understand the product
+- output quality is consistently useful
+- onboarding/demo flow is smooth
+- pricing and positioning are validated


### PR DESCRIPTION
## Summary

Adds the final Pilot RC1 launch candidate summary for controlled pilot readiness.

## What changed

Creates `docs/pilot/pilot_rc1_launch_candidate_summary.md`.

The document summarizes:

- current product status
- controlled pilot readiness score
- supported external positioning
- golden gate evidence
- trust and safety validation
- operational hardening
- known limits
- recommended demo flow
- pilot success criteria
- launch decision

## Current readiness

Pilot RC1 is documented as ready for controlled pilot demos.

Current readiness interpretation:

- 92-95 / 100 controlled pilot readiness
- latest hardened golden gate score: 95.5 / 100
- passing samples: 4 / 4

## Supported external positioning

The strongest supported claim remains intentionally narrow:

Best for short, structured business meetings.

## Trust and safety

Meeting 86 remains the key safety benchmark and confirms that unclear/non-meeting audio is not converted into fake business decisions or fake action items.

Latest documented result:

- decisions: 0
- action items: 0
- safety signal: true

## Launch decision

The summary recommends proceeding with 3-5 trusted first-user pilots.

It also recommends not broadening to public launch until pilot feedback confirms:

- users understand the product
- output quality is consistently useful
- onboarding/demo flow is smooth
- pricing and positioning are validated

## Validation

Documentation-only change.

Pre-commit checks passed:

- ruff skipped, no code files
- ruff format skipped, no code files
- mypy skipped, no code files
- fix end of files passed
- trim trailing whitespace passed